### PR TITLE
Add `sysenter` fast system call support to DragonWare's kernel

### DIFF
--- a/base/fbsrv/main.c
+++ b/base/fbsrv/main.c
@@ -18,8 +18,6 @@
 #include "ps2kbd/protocol.h"
 
 int main(void) {
-        if (_DWRaiseIOPL() != STATUS_OK) return -1;
-
         /* The framebuffer server also provides the system console. It may become optional in the
          * far future, but until then, this driver has two responsibilities (And even more under the
          * hood)*/

--- a/base/ps2kbd/ps2kbd.c
+++ b/base/ps2kbd/ps2kbd.c
@@ -177,8 +177,12 @@ static Status Probe8042Controller(void) {
 }
 
 int main(void) {
-        /* We need IOPL support from the kernel to read the bytes from the controller. */
-        if (_DWRaiseIOPL() != STATUS_OK) return -1;
+        /* We need IO port access from the kernel to read the bytes from the controller. Note that
+         * PS2_PORT_COMMAND is the same as PS2_PORT_STATUS in this case so no reason to also specify
+         * it */
+        u16 ports_needed[] = {PS2_PORT_STATUS, PS2_PORT_DATA};
+        if (_DWRequestPorts(ports_needed, 2) != STATUS_OK) return -1;
+
         if (Probe8042Controller() != STATUS_OK) {
                 _DWklog(LOG_ERROR, "Unable to probe i8042 controller. Keyboard will be disabled.");
                 return -0xDD;

--- a/base/vgacons/console.c
+++ b/base/vgacons/console.c
@@ -30,9 +30,10 @@ static inline void VGAEnableCursor(u8 cursor_start, u8 cursor_end) {
 }
 
 int main(void) {
-        /* Need IOPL permissions to control the VGA cursor */
-        if (_DWRaiseIOPL() != STATUS_OK) return -1;
-        VGAEnableCursor(0, 15);
+        /* Need IOPL permissions to control the VGA cursor. If the kernel rejects the request, leave
+         * the cursor as is. */
+        u16 ports_needed[] = {0x3D4, 0x3D5};
+        if (_DWRequestPorts(ports_needed, 2) == STATUS_OK) VGAEnableCursor(0, 15);
 
         /* Device object, to claim the VGA text mode driver from the kernel */
         Handle consoledev = CreateObject(NullPointer, OBJ_DEVICE, 0);

--- a/bootmanager/core/fs/fat32/fat32.c
+++ b/bootmanager/core/fs/fat32/fat32.c
@@ -140,7 +140,6 @@ static void FATEntryToString(const char *raw, char *dest) {
         }
 
         dest[d_ptr] = '\0';
-        DebugPrint("New filename: %s", dest);
 }
 
 static Status ScanDirectoryFor(const Partition p, BIOSParameterBlock *bpb, u32 cluster,

--- a/bootmanager/core/fs/fat32/fat32.c
+++ b/bootmanager/core/fs/fat32/fat32.c
@@ -140,6 +140,7 @@ static void FATEntryToString(const char *raw, char *dest) {
         }
 
         dest[d_ptr] = '\0';
+        DebugPrint("New filename: %s", dest);
 }
 
 static Status ScanDirectoryFor(const Partition p, BIOSParameterBlock *bpb, u32 cluster,

--- a/bootmanager/core/init/main.c
+++ b/bootmanager/core/init/main.c
@@ -320,6 +320,7 @@ void bootmain(void) {
                 AddEntry("Boot DragonWare (Default hard drive, video mode)", 2,
                          BootDragonWareDefaultOptions);
         }
+        AddEntry("Boot DragonWare (Default hard drive, text mode)", 1, BootDragonWareVGATextMode);
         AddEntry("Reboot", 3, ForceReboot);
 
         DrawUserInterface();

--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -10,13 +10,17 @@
 #pragma once
 
 #ifndef _KERNEL_API_H
-#define _KERNEL_API_H           1
+#define _KERNEL_API_H    1
 
-#define SYSCALL_IDENTIFY        (0)
-#define SYSCALL_EXIT            (1)
-#define SYSCALL_YIELD           (2)
-#define SYSCALL_KLOG            (3)
-#define SYSCALL_RAISE_IOPL      (4)
+#define SYSCALL_IDENTIFY (0)
+#define SYSCALL_EXIT     (1)
+#define SYSCALL_YIELD    (2)
+#define SYSCALL_KLOG     (3)
+#if 0
+#define SYSCALL_RAISE_IOPL (4)
+#else
+#define SYSCALL_REQUEST_PORTS (4)
+#endif /* SYSCALL_RAISE_IOPL */
 #define SYSCALL_SEND            (5)
 #define SYSCALL_RECEIVE         (6)
 #define SYSCALL_TICK_SINCE_BOOT (7)
@@ -29,8 +33,9 @@
 #include "ipc86.h"
 #include "kerneltypes.h"
 
-#define SI_MAX_NAME (24)
-#define SI_MAX_TAG  (12)
+#define SI_MAX_NAME              (24)
+#define SI_MAX_TAG               (12)
+#define MAX_IO_PORTS_PER_PROCESS (20)
 
 DW_BEGIN_DECLS
 
@@ -191,8 +196,27 @@ void _cdecl _DWklog(LogLevel level, const char *msg);
  * @return STATUS_OK if the process has the capability to talk to I/O ports directly.
  * STATUS_UNSUPPORTED if the process is not allowed to talk to I/O ports because it lacks the
  * kernel-assigned capability.
+ * @deprecated This function has been deprecated in favour of the more secure @ref _DWRequestPorts
+ * and no longer has any effect. It is only kept here until the transition has fully finished.
  */
-Status _cdecl _DWRaiseIOPL(void);
+[[deprecated(
+        "_DWRaiseIOPL has been dropped due to security and compatibility constraints. It has been "
+        "replaced by _DWRequestPorts")]] Status _cdecl _DWRaiseIOPL(void);
+
+/**
+ * @brief _DWRequestPorts system call (#4) wrapper.
+ * @details This function requests from the kernel permission to directly read from the I/O ports
+ * specified inside @p port_list, an array of 16-bit integers of ports that the process needs to
+ * talk to. This function replaces the legacy and insecure @ref _DWRaiseIOPL function and also
+ * provides compatibility with the new system call convention more easily.
+ * @param[in] port_list An array of ports that the process wants to talk to. Elements beyond @ref
+ * MAX_IO_PORT_PER_PROCESS will be ignored.
+ * @param[in] port_list_size The amount of ports to read from the array.
+ * @returns STATUS_OK if the process has been granted the ability to talk to ports. Other @ref
+ * Status codes if it failed, depending on the reason of failure.
+ * @since v0.0.2
+ */
+Status _cdecl _DWRequestPorts(const u16 *port_list, Size port_list_size);
 
 /**
  * @brief _DWIPCSend system call (#5) wrapper

--- a/dwuser/syscall/syscall.c
+++ b/dwuser/syscall/syscall.c
@@ -26,9 +26,16 @@ void _cdecl _DWklog(LogLevel level, const char *msg) {
         __make_syscall_ia32_2param(SYSCALL_KLOG, (u32)level, (u32)msg);
 }
 
+#if 0
 Status _cdecl _DWRaiseIOPL(void) {
         return (Status)__make_syscall_ia32_0param_reti32(SYSCALL_RAISE_IOPL);
 }
+#else
+Status _cdecl _DWRequestPorts(const u16 *port_list, Size port_list_size) {
+        return (Status)__make_syscall_ia32_2param_reti32(SYSCALL_REQUEST_PORTS, (uint32_t)port_list,
+                                                         (uint32_t)port_list_size);
+}
+#endif /* DRAGONWARE_VERSION_PATCH */
 
 Status _cdecl _DWIPCSend(int handle, Message *m, Size message_size) {
         return __make_syscall_ia32_3param_reti32(SYSCALL_SEND, handle, (u32)m, (u32)message_size);

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -11,7 +11,10 @@ set(COMPAT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/compat/arith64.c)
 set(INCLUDEDIRS    ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/base)
 
 if (${ARCH} STREQUAL "IA32")
-        list(APPEND ASM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/syscalls/syscall86.asm ${CMAKE_CURRENT_SOURCE_DIR}/crt0.asm)
+        list(APPEND ASM_SRC
+             ${CMAKE_CURRENT_SOURCE_DIR}/syscalls/syscall86.asm
+             ${CMAKE_CURRENT_SOURCE_DIR}/crt0.asm
+             ${CMAKE_CURRENT_SOURCE_DIR}/arch/ia32/string.asm)
 endif()
 
 add_library(dlibc STATIC ${GENERIC_SOURCES} ${SYSCALL_SOURCES} ${COMPAT_SOURCES} ${ASM_SRC})

--- a/libc/arch/ia32/string.asm
+++ b/libc/arch/ia32/string.asm
@@ -1,0 +1,139 @@
+; ----------------------------------------------------------------------------------------
+; FILE: string.asm
+; PURPOSE: String and memory manipulation standard functions implemented in x86 assembly
+; PROJECT: DragonWare C Library
+; DATE: 06-2026
+; AUTHOR: Aggelos Tselios <aggelostselios777@gmail.com>
+; LICENSE: GPL-v3.0-or-later, see COPYING in the toplevel directory
+; ----------------------------------------------------------------------------------------
+
+section .text
+global  memcpy
+global  memset
+global  strcpy
+global  strlen
+global  memcmp
+
+memcpy:
+        push    ebp
+        mov     ebp,    esp
+
+        push    esi
+        push    edi
+
+        mov     ecx,    [ebp+16]
+        test    ecx,    ecx
+        jz      .done
+
+        mov     edi,    [ebp+8]
+        mov     esi,    [ebp+12]
+        mov     eax,    edi
+
+        mov     edx,    ecx
+        shr     ecx,    2
+        rep     movsd
+
+        mov     ecx,    edx
+        and     ecx,    3
+        rep     movsb
+.done:
+        mov     eax,    [ebp+8]
+        pop     edi
+        pop     esi
+        pop     ebp
+        ret
+
+memset:
+        push    ebp
+        mov     ebp,    esp
+
+        push    edi
+        mov     edi,            [ebp+8]
+        movzx   eax,    byte    [ebp+12]
+        mov     ecx,            [ebp+16]
+
+        ; Copy the byte in AL to all 4 bytes of EAX, so that movsd
+        ; can work. So if al is 0xAB, EAX will become 0xABABABAB
+        ; No that wasn't my idea I'm not that genius, but apparently it works
+        imul    eax,    0x01010101
+        
+        mov     edx,    ecx
+        shr     ecx,    2
+        rep     stosd
+        
+        mov     ecx,    edx
+        and     ecx,    3
+        rep     stosb
+
+        mov     eax,    [ebp+8]
+        pop     edi
+        pop     ebp
+        ret
+
+memcmp:
+        push    ebp
+        mov     ebp,    esp
+        push    esi
+        push    edi
+
+        mov     esi,    [ebp+8]
+        mov     edi,    [ebp+12]
+        mov     ecx,    [ebp+16]
+
+        test    ecx,    ecx
+        jz      .match
+
+        repe    cmpsb
+        je      .match
+
+        movzx   eax,    byte [esi-1]
+        movzx   edx,    byte [edi-1]
+        sub     eax,    edx
+        jmp     .done
+.match:
+        xor     eax,    eax
+.done:
+        pop     edi
+        pop     esi
+        pop     ebp
+        ret
+
+strcpy:
+        push    ebp
+        mov     ebp,    esp
+
+        push    edi
+        push    esi
+
+        mov     edi,    [ebp+8]
+        mov     esi,    [ebp+12]
+
+.loop:
+        mov     al,     [esi]
+        mov     [edi],  al
+
+        inc     esi
+        inc     edi
+
+        test    al,     al
+        jnz     .loop
+.done:
+        mov     eax,    [ebp+8]
+        pop     esi
+        pop     edi
+        pop     ebp
+        ret
+
+strlen:
+        push    ebp
+        mov     ebp,    esp
+        mov     eax,    [ebp+8]
+.len_loop:
+        cmp     byte    [eax],  0
+        je      .done
+        inc     eax
+        jmp     .len_loop
+.done:
+        sub     eax,    [ebp+8]
+        pop     ebp
+        ret

--- a/libc/generic/init.c
+++ b/libc/generic/init.c
@@ -12,6 +12,10 @@
 
 #include "syscalls/syscall86.h"
 
+/* Defined in syscalls/syscall86.asm. Enables sysenter support for the userland if supported,
+ otherwise falls back to the int 0x60 way of doing system calls. */
+extern int __libc_try_enable_sysenter(void);
+
 /* XXX We can't use the dwuser library here - We would have a circular dependency. So we have to
  * perform the system calls manually. Luckily I don't plan on moving system calls around, so
  * this will work for some time, although fragile.*/
@@ -38,7 +42,10 @@ static void __libc_register_handles(void) {
         if (invoke_status != STATUS_OK) __dlibc_console_handle = -1;
 }
 
-void __libc_init_internal(void) { __libc_register_handles(); }
+void __libc_init_internal(void) {
+        __libc_try_enable_sysenter();
+        __libc_register_handles();
+}
 
 [[gnu::visibility("hidden")]]
 void __libc_cleanup(void) {

--- a/libc/generic/string.c
+++ b/libc/generic/string.c
@@ -11,17 +11,6 @@
 
 #include "stdlib.h"
 
-void *memcpy(void *restrict dest, const void *restrict src, size_t size) {
-        if (!size) return dest;
-
-        char       *d = dest;
-        const char *s = src;
-        while (size--) {
-                d[size] = s[size];
-        }
-        return dest;
-}
-
 void *memmove(void *dest, const void *src, size_t size) {
         if (!size || dest == src) return dest;
 
@@ -36,41 +25,6 @@ void *memmove(void *dest, const void *src, size_t size) {
                 while (size--) *--d = *--s;
         }
         return dest;
-}
-
-void *memset(void *dest, int value, size_t size) {
-        uint8_t *d = dest;
-        while (size--) *d++ = (uint8_t)value;
-        return dest;
-}
-
-int memcmp(const void *s1, const void *s2, size_t n) {
-        const unsigned char *a = s1;
-        const unsigned char *b = s2;
-
-        for (; n; n--, a++, b++) {
-                if (*a != *b) return *a - *b;
-        }
-        return 0;
-}
-
-char *strcpy(char *dest, const char *src) {
-        char *ret = dest;
-        while ((*dest++ = *src++)); /* shut up clang*/
-
-        return ret;
-}
-
-char *strncpy(char *dest, const char *src, size_t n) {
-        char *ret = dest;
-        while (n && *src) {
-                *dest++ = *src++;
-                n--;
-        }
-        while (n--) {
-                *dest++ = '\0';
-        }
-        return ret;
 }
 
 char *strcat(char *dest, const char *src) {
@@ -89,6 +43,18 @@ char *strncat(char *dest, const char *src, size_t n) {
                 n--;
         }
         *dest = '\0';
+        return ret;
+}
+
+char *strncpy(char *dest, const char *src, size_t n) {
+        char *ret = dest;
+        while (n && *src) {
+                *dest++ = *src++;
+                n--;
+        }
+        while (n--) {
+                *dest++ = '\0';
+        }
         return ret;
 }
 
@@ -120,12 +86,6 @@ char *strchr(const char *s, int c) {
                 s++;
         }
         return ch == '\0' ? (char *)s : NULL;
-}
-
-size_t strlen(const char *s) {
-        const char *p = s;
-        while (*p) p++;
-        return (size_t)(p - s);
 }
 
 /*

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -14,18 +14,114 @@
 
 DLC_BEGIN_DECLS
 
-void  *memcpy(void *restrict dest, const void *restrict src, size_t size);
-void  *memmove(void *dest, const void *src, size_t size);
-void  *memset(void *dest, int value, size_t size);
-int    memcmp(const void *p1, const void *p2, size_t n);
-char  *strcpy(char *dest, const char *src);
-char  *strncpy(char *dest, const char *src, size_t size);
-char  *strcat(char *dest, const char *src);
-char  *strncat(char *dest, const char *src, size_t n);
-int    strcmp(const char *s1, const char *s2);
-int    strncmp(const char *s1, const char *s2, size_t n);
-char  *strchr(const char *s, int c);
+/**
+ * @brief Copies @p size amount of bytes from @p src to @p dest following the semantics of the C
+ * standard.
+ * @note Overlapping pointers are not considered by this function. If @p src and @p dest overlap, it
+ * is undefined behaviour.
+ * @param[out] dest Pointer to the address to copy the data to.
+ * @param[in] src Pointer to the address to copy from.
+ * @param size Amount of bytes to copy.
+ * @returns @p dest
+ */
+void *memcpy(void *dest, const void *src, size_t size);
+
+/**
+ * @brief Copies @p size bytes from @p src to @p dest while safely handling overlapping regions.
+ * @note The difference between this and @ref memcpy is the way they handle overlapping pointers.
+ * Passing two overlapping pointers in @ref memcpy is undefined behaviour, but memmove checks if the
+ * two pointers overlap and copies the data in a safe way if they do.
+ * @param[out] dest Pointer to the address to copy to. Passing @ref NULL is undefined behaviour.
+ * @param[in] src Pointer to the address to copy from. Passing @ref NULL is undefined behaviour.
+ * @param size Amount of bytes to copy.
+ * @sa memcpy
+ * @returns @p dest
+ */
+void *memmove(void *dest, const void *src, size_t size);
+
+/**
+ * @brief Starting at the memory address pointed to by @p dest, writes @p value to @p dest for @p
+ * size bytes.
+ * @note Only the lower eight bits of @p value are considered in the store operation.
+ * @param[out] dest Address to write @p value to.
+ * @param value Value to write.
+ * @param size Amount of @p value to write starting at @p dest
+ * @returns @p dest
+ */
+void *memset(void *dest, int value, size_t size);
+
+/**
+ * @brief Compares @p n bytes and returns the result
+ * @param[in] p1 Pointer to the first object to compare.
+ * @param[in] p2 Pointer to the second object to compare.
+ * @param n Amount of bytes to compare.
+ * @returns A negative value if the first different byte in @p p1 is less than @p p2, a positive
+ * value if the first different byte in @p p1 is greater than @p p2 or 0 if the @p n bytes of @p p1 and
+ * @p p2 are equal.
+ */
+int memcmp(const void *p1, const void *p2, size_t n);
+
+/**
+ * @brief Copies @p src to @p dest up until finding a NULL byte.
+ * @param[out] dest Destination to copy the string to.
+ * @param[in] src Source string to copy from.
+ * @note The NULL terminating byte is copied as well and does not need to be written manually at the end of @p dest by the caller.
+ * @returns @p dest
+ */
+char *strcpy(char *dest, const char *src);
+
+/**
+ * @brief Copies @p src to @p dest up until finding a NULL byte OR reaching @p size without finding
+ * a NULL byte. In case a NULL byte was found in @p src within @p size bytes, then the
+ * rest of @p dest is filled with zeroes.
+ * @param[out] dest Destination to copy the string to.
+ * @param[in] src Source string to copy from.
+ * @param size Amount of bytes to copy.
+ * @returns @p dest
+ */
+char *strncpy(char *dest, const char *src, size_t size);
+
+char *strcat(char *dest, const char *src);
+
+char *strncat(char *dest, const char *src, size_t n);
+
+/**
+ * @brief Compares two NULL terminated strings and returns the result.
+ * @param[in] s1 First string to compare.
+ * @param[in] s2 Second string to compare.
+ * @returns A positive value if @p s1 is greater than @p s2, a negative value of @p s1 is lesser
+ * than @p s2, or 0 if the two strings are equal.
+ */
+int strcmp(const char *s1, const char *s2);
+
+/**
+ * @brief Compares two NULL terminated strings and returns the result, for up to @p n bytes or until
+ * reaching the NULL terminator of one of them.
+ * @param[in] s1 First string to compare.
+ * @param[in] s2 Second string to compare.
+ * @param n Amount of characters to compare.
+ * @returns A positive value if the character of @p s1 is greater than the character of @p s2 at the
+ * offset where the two strings differ, a negative value if the character of @p s1 is lesser than
+ * the character of @p s2 at the offset where the two strings differ, or 0 if the two strings are
+ * equal up until @p n bytes.
+ * @sa strncmp
+ */
+int strncmp(const char *s1, const char *s2, size_t n);
+
+/**
+ * @brief Searches for a given character within @p s and returns a pointer within @p s pointing to
+ * the first occurence of that byte.
+ * @param[in] s String to search into.
+ * @param c Character to search for.
+ * @returns Pointer to the character @p c within @p s or @ref NULL if the character @p c was not found
+ */
+char *strchr(const char *s, int c);
+
+/**
+ * @brief Returns the length of the NULL terminated string given.
+ * @param[in] s String to get the length of.
+ * @returns Length of @p s without including the NULL terminator.
+ */
 size_t strlen(const char *s);
-char  *strdup(const char *s);
 
 DLC_END_DECLS

--- a/libc/include/syscalls/syscall86.h
+++ b/libc/include/syscalls/syscall86.h
@@ -18,8 +18,6 @@ extern void __make_syscall_ia32_3param(int syscall, uint32_t __param1, uint32_t 
                                        uint32_t __param3);
 extern void __make_syscall_ia32_4param(int syscall, uint32_t __param1, uint32_t __param2,
                                        uint32_t __param3, uint32_t __param4);
-extern void __make_syscall_ia32_5param(int syscall, uint32_t __param1, uint32_t __param2,
-                                       uint32_t __param3, uint32_t __param4, uint32_t __param5);
 
 extern uint32_t __make_syscall_ia32_0param_reti32(int syscall);
 extern uint32_t __make_syscall_ia32_1param_reti32(int syscall, uint32_t __param);
@@ -29,6 +27,3 @@ extern uint32_t __make_syscall_ia32_3param_reti32(int syscall, uint32_t __param1
                                                   uint32_t __param3);
 extern uint32_t __make_syscall_ia32_4param_reti32(int syscall, uint32_t __param1, uint32_t __param2,
                                                   uint32_t __param3, uint32_t __param4);
-extern uint32_t __make_syscall_ia32_5param_reti32(int syscall, uint32_t __param1, uint32_t __param2,
-                                                  uint32_t __param3, uint32_t __param4,
-                                                  uint32_t __param5);

--- a/libc/syscalls/syscall86.asm
+++ b/libc/syscalls/syscall86.asm
@@ -7,9 +7,13 @@
 ; LICENSE: GPL-v3.0-or-later, see COPYING in the toplevel directory
 ; ----------------------------------------------------------------------------------------
 
-%define DRAGONWARE_NATIVE_SYSCALL       int 0x60
-%define DRAGONWARE_UNI_SYSCALL          int 0x80
+section .data
+; By default, good old software interrupts will be used for system calls
+__syscall_gate_internal:
+        dd     __syscall_trap_int0x60
 
+section .text
+global __libc_try_enable_sysenter
 global __make_syscall_ia32_0param
 global __make_syscall_ia32_1param
 global __make_syscall_ia32_2param
@@ -21,22 +25,59 @@ global __make_syscall_ia32_1param_reti32
 global __make_syscall_ia32_2param_reti32
 global __make_syscall_ia32_3param_reti32
 global __make_syscall_ia32_4param_reti32
-global __make_syscall_ia32_5param_reti32
+
+; Checks if the machine supports sysenter. Returns 0 if it is supported,
+; 1 if it isn't. Assumes the host computer supports the cpuid instruction.
+; TODO: Obviously, if the host machine doesn't support CPUID, we should check that,
+; or put the check behind _DW_LEGACY_SUPPORT that is specifically for pre-Pentium II CPUs.
+; Also, AMD chips often don't play well with sysenter and sysexit. There should be a check for that too
+; in here.
+__libc_check_sysenter:
+        push    ebx
+        mov     eax,    0x01
+        cpuid
+        test    edx,    0x800   ; Bit 11 (SEP)
+        pop     ebx
+        jz      .not_supported
+        xor     eax,    eax
+        ret
+.not_supported:
+        mov     eax,    0x01
+        ret
+
+__syscall_trap_int0x60:
+        int     0x60
+        ret
+
+__syscall_trap_sysenter:
+        mov     ecx,    esp
+        mov     edx,    .ReturnFromSysenter
+        sysenter
+.ReturnFromSysenter:
+        ret
+
+__libc_try_enable_sysenter:
+        call    __libc_check_sysenter
+        test    eax,    eax
+        jz .EnableSysenter
+        mov dword       [__syscall_gate_internal], __syscall_trap_int0x60
+        ret
+.EnableSysenter:
+        mov dword       [__syscall_gate_internal], __syscall_trap_sysenter
+        ret
 
 __make_syscall_ia32_0param:
         mov     eax,    [esp+4]
-        DRAGONWARE_NATIVE_SYSCALL
+        call    [__syscall_gate_internal]
         ret
-
 
 __make_syscall_ia32_1param:
         push    ebx
         mov     eax,    [esp+8]
         mov     ebx,    [esp+12]
 
-        DRAGONWARE_NATIVE_SYSCALL
-
-        pop	ebx
+        call    [__syscall_gate_internal]
+        pop     ebx
         ret
 
 
@@ -47,7 +88,7 @@ __make_syscall_ia32_2param:
         mov     eax, [esp+12]
         mov     ebx, [esp+16]
         mov     esi, [esp+20]
-        DRAGONWARE_NATIVE_SYSCALL
+        call    [__syscall_gate_internal]
 
 	pop	esi
         pop	ebx
@@ -62,7 +103,7 @@ __make_syscall_ia32_3param:
         mov     ebx, [esp+20]
         mov     esi, [esp+24]
         mov     edi, [esp+28]
-        DRAGONWARE_NATIVE_SYSCALL
+        call    [__syscall_gate_internal]
 
 	pop	edi
 	pop	esi
@@ -81,14 +122,13 @@ __make_syscall_ia32_4param:
         mov     esi, [esp+28]
         mov     edi, [esp+32]
         mov     ebp, [esp+36]
-        DRAGONWARE_NATIVE_SYSCALL
+        call    [__syscall_gate_internal]
 
 	pop	ebp
 	pop	edi
 	pop	esi
 	pop	ebx
         ret
-
 
 ; Since the argument is returned in eax by the kernel, these are the same routines
 ; more or less, so a simple jump will suffice.

--- a/libc/syscalls/syscall86.asm
+++ b/libc/syscalls/syscall86.asm
@@ -10,21 +10,11 @@
 %define DRAGONWARE_NATIVE_SYSCALL       int 0x60
 %define DRAGONWARE_UNI_SYSCALL          int 0x80
 
-%macro SAVE_BASE_POINTER 0
-        push    ebp
-        mov     ebp, esp
-%endmacro
-
-%macro RESTORE_BASE_POINTER 0
-        pop ebp
-%endmacro
-
 global __make_syscall_ia32_0param
 global __make_syscall_ia32_1param
 global __make_syscall_ia32_2param
 global __make_syscall_ia32_3param
 global __make_syscall_ia32_4param
-global __make_syscall_ia32_5param
 
 global __make_syscall_ia32_0param_reti32
 global __make_syscall_ia32_1param_reti32
@@ -34,99 +24,71 @@ global __make_syscall_ia32_4param_reti32
 global __make_syscall_ia32_5param_reti32
 
 __make_syscall_ia32_0param:
-        SAVE_BASE_POINTER
-
-        mov     eax, [ebp+8]
+        mov     eax,    [esp+4]
         DRAGONWARE_NATIVE_SYSCALL
-
-        RESTORE_BASE_POINTER
         ret
 
 
 __make_syscall_ia32_1param:
-        SAVE_BASE_POINTER
         push    ebx
+        mov     eax,    [esp+8]
+        mov     ebx,    [esp+12]
 
-        mov     eax, [ebp+8]
-        mov     ebx, [ebp+12]
         DRAGONWARE_NATIVE_SYSCALL
 
-        pop ebx
-
-        RESTORE_BASE_POINTER
+        pop	ebx
         ret
 
 
 __make_syscall_ia32_2param:
-        SAVE_BASE_POINTER
         push    ebx
+	push	esi
 
-        mov     eax, [ebp+8]
-        mov     ebx, [ebp+12]
-        mov     ecx, [ebp+16]
+        mov     eax, [esp+12]
+        mov     ebx, [esp+16]
+        mov     esi, [esp+20]
         DRAGONWARE_NATIVE_SYSCALL
 
-        pop ebx
-
-        RESTORE_BASE_POINTER
+	pop	esi
+        pop	ebx
         ret
 
-
 __make_syscall_ia32_3param:
-        SAVE_BASE_POINTER
         push    ebx
+	push	esi
+	push	edi
 
-        mov     eax, [ebp+8]
-        mov     ebx, [ebp+12]
-        mov     ecx, [ebp+16]
-        mov     edx, [ebp+20]
+        mov     eax, [esp+16]
+        mov     ebx, [esp+20]
+        mov     esi, [esp+24]
+        mov     edi, [esp+28]
         DRAGONWARE_NATIVE_SYSCALL
 
-        pop ebx
-
-        RESTORE_BASE_POINTER
+	pop	edi
+	pop	esi
+        pop	ebx
         ret
 
 
 __make_syscall_ia32_4param:
-        SAVE_BASE_POINTER
         push    ebx
         push    esi
+	push	edi
+	push	ebp
 
-        mov     eax, [ebp+8]
-        mov     ebx, [ebp+12]
-        mov     ecx, [ebp+16]
-        mov     edx, [ebp+20]
-        mov     esi, [ebp+24]
+        mov     eax, [esp+20]
+        mov     ebx, [esp+24]
+        mov     esi, [esp+28]
+        mov     edi, [esp+32]
+        mov     ebp, [esp+36]
         DRAGONWARE_NATIVE_SYSCALL
 
-        pop esi
-        pop ebx
-
-        RESTORE_BASE_POINTER
+	pop	ebp
+	pop	edi
+	pop	esi
+	pop	ebx
         ret
 
-
-__make_syscall_ia32_5param:
-        SAVE_BASE_POINTER
-        push    ebx
-        push    esi
-        push    edi
-
-        mov     eax, [ebp+8]
-        mov     ebx, [ebp+12]
-        mov     ecx, [ebp+16]
-        mov     edx, [ebp+20]
-        mov     esi, [ebp+24]
-        mov     edi, [ebp+28]
-        DRAGONWARE_NATIVE_SYSCALL
-
-        pop edi
-        pop esi
-        pop ebx
-
-        RESTORE_BASE_POINTER
-        ret
 
 ; Since the argument is returned in eax by the kernel, these are the same routines
 ; more or less, so a simple jump will suffice.
@@ -144,6 +106,3 @@ __make_syscall_ia32_3param_reti32:
 
 __make_syscall_ia32_4param_reti32:
         jmp __make_syscall_ia32_4param
-
-__make_syscall_ia32_5param_reti32:
-        jmp __make_syscall_ia32_5param

--- a/sys/ddk/ia32/gdt.c
+++ b/sys/ddk/ia32/gdt.c
@@ -113,7 +113,7 @@ void GDTInit(void) {
         tss0.esp0       = (u32)(((uintptr_t)tss_stack) + sizeof(tmp_tss_stack));
         tss0.iomap_base = sizeof(tss0);
         tss0.terminator = 0xFF;
-        GDTSetGate(5, (u32)&tss0, sizeof(tss0) - 1, 0x89, 0x00);
+        GDTSetGate(5, (u32)&tss0, sizeof(tss0) - 1, GDT_ACCESS_PRESENT | GDT_TYPE_TSS, 0x00);
 
         FlushGDT((u32)&gdtptr);
 

--- a/sys/ddk/ia32/gdt.c
+++ b/sys/ddk/ia32/gdt.c
@@ -106,12 +106,14 @@ void GDTInit(void) {
         /* This part is for the TSS that requires some different code but
          * whatever*/
         kzeromem(&tss0, sizeof(TSSEntry));
+        memset(tss0.ioperm, 0xFF, TSS_IOPERM_SIZE);
 
         /* Fallback stack, each process will remove this after a while */
         tss0.ss0        = SEL_DATA_KERNEL;
         tss0.esp0       = (u32)(((uintptr_t)tss_stack) + sizeof(tmp_tss_stack));
         tss0.iomap_base = sizeof(tss0);
-        GDTSetGate(5, (u32)&tss0, sizeof(tss0) - 1, GDT_ACCESS_PRESENT | GDT_TYPE_TSS, 0x00);
+        tss0.terminator = 0xFF;
+        GDTSetGate(5, (u32)&tss0, sizeof(tss0) - 1, 0x89, 0x00);
 
         FlushGDT((u32)&gdtptr);
 
@@ -127,4 +129,28 @@ void SelectKernelStack(uintptr_t stack_top) {
 #ifndef _LEGACY_SUPPORT
         if (likely(x86FeatureSupported(X86_SYSENTER))) SwitchSysenterStack(stack_top);
 #endif /* _LEGACY_SUPPORT */
+}
+
+void EnableIOPortsOfProcess(Process *p) {
+        if (!p->ports_used) {
+                tss0.iomap_base = sizeof(TSSEntry);
+                return;
+        } else
+                tss0.iomap_base = offsetof(TSSEntry, ioperm);
+        for (u16 i = 0; i < p->ports_used; i++) {
+                u16 port = p->ioports[i];
+                tss0.ioperm[port / 8] &= ~(1 << (port % 8));
+        }
+}
+
+void DisableIOPortsOfProcess(Process *p) {
+        if (!p->ports_used) {
+                tss0.iomap_base = sizeof(TSSEntry);
+                return;
+        } else
+                tss0.iomap_base = offsetof(TSSEntry, ioperm);
+        for (u16 i = 0; i < p->ports_used; i++) {
+                u16 port = p->ioports[i];
+                tss0.ioperm[port / 8] |= (1 << (port % 8));
+        }
 }

--- a/sys/ddk/ia32/idt.c
+++ b/sys/ddk/ia32/idt.c
@@ -129,14 +129,32 @@ static void InstallInterruptServiceRoutines(void) {
         IRQInstall();
 }
 
+/* I should probably find a better name for this function */
+[[gnu::hot]]
+static inline void CopySyscallState(SystemCallFrame *state, InterruptStackFrame *frame) {
+        frame->eax    = state->eax;    /* Return value */
+        frame->ebx    = state->ebx;    /* Argument 0 that (may) be returned from the kernel */
+        frame->esi    = state->esi;    /* Argument 1 that (may) be returned from the kernel */
+        frame->edi    = state->edi;    /* Argument 2 that (may) be returned from the kernel */
+        frame->ebp    = state->ebp;    /* Argument 3 that (may) be returned from the kernel */
+        frame->eflags = state->eflags; /* eflags that may have been modified by the kernel. For now,
+                                          this is only relevant for _DWRaiseIOPL()  */
+}
+
 [[gnu::hot]]
 void InterruptServiceHandler(InterruptStackFrame *stack_frame) {
         if (stack_frame->int_no == SYSCALL_NO) {
-                DragonWareSyscall(stack_frame);
+                SystemCallFrame f;
+                SyscallFrameFromInterrupt(stack_frame, &f);
+                DragonWareSyscall(&f);
+                CopySyscallState(&f, stack_frame);
                 return;
         }
         if (stack_frame->int_no == SYSCALL_NO + 0x20) {
-                POSIXSyscall(stack_frame);
+                SystemCallFrame f;
+                SyscallFrameFromInterrupt(stack_frame, &f);
+                POSIXSyscall(&f);
+                CopySyscallState(&f, stack_frame);
                 return;
         }
 

--- a/sys/ddk/ia32/idt.c
+++ b/sys/ddk/ia32/idt.c
@@ -132,13 +132,11 @@ static void InstallInterruptServiceRoutines(void) {
 /* I should probably find a better name for this function */
 [[gnu::hot]]
 static inline void CopySyscallState(SystemCallFrame *state, InterruptStackFrame *frame) {
-        frame->eax    = state->eax;    /* Return value */
-        frame->ebx    = state->ebx;    /* Argument 0 that (may) be returned from the kernel */
-        frame->esi    = state->esi;    /* Argument 1 that (may) be returned from the kernel */
-        frame->edi    = state->edi;    /* Argument 2 that (may) be returned from the kernel */
-        frame->ebp    = state->ebp;    /* Argument 3 that (may) be returned from the kernel */
-        frame->eflags = state->eflags; /* eflags that may have been modified by the kernel. For now,
-                                          this is only relevant for _DWRaiseIOPL()  */
+        frame->eax = state->eax; /* Return value */
+        frame->ebx = state->ebx; /* Argument 0 that (may) be returned from the kernel */
+        frame->esi = state->esi; /* Argument 1 that (may) be returned from the kernel */
+        frame->edi = state->edi; /* Argument 2 that (may) be returned from the kernel */
+        frame->ebp = state->ebp; /* Argument 3 that (may) be returned from the kernel */
 }
 
 [[gnu::hot]]

--- a/sys/ddk/ia32/sysenter.asm
+++ b/sys/ddk/ia32/sysenter.asm
@@ -43,55 +43,46 @@ EnableSysenter:
         pop     ebp
         ret
 
-; System calls expect this frame:
-; typedef struct _InterruptStackFrame {
-;         u32 gs, fs, es, ds;
-;         u32 edi, esi, ebp, esp, ebx, edx, ecx, eax;
-;         u32 int_no;
-;         u32 err_code;
-;         u32 eip, cs, eflags;
-;         u32 useresp, ss;
-; } InterruptStackFrame;
-; Obviously most of the fields are unused in this frame, so...
-; TODO: Use a dedicated SystemCallRegisters for system calls to avoid pushing unnecessary
-; state here.
 ;
+; System calls expect this frame:
+; typedef struct [[gnu::packed]] _SystemCallFrame {
+;         u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
+;         u32 eax;                /* System call number */
+;         u32 eflags;             /* Used for _DWRaiseIOPL only */
+; } SystemCallFrame;
+;
+; We construct it upon entry and then call the system call handler to handle the actual userland system call.
 ; NOTE: Userland doesn't make use of this code yet. It uses the traditional software interrupt method for now.
 ; Meaning this code here is just a stub for the future, and has not been tested yet.
-; In fact, the system call ABI used by DragonWare requires the third and fourth arguments to be passed in ecx/edx,
-; which are also used by sysenter/sysexit to find the return address and the user stack. Meaning if you just tried to
-; use it anyways, best case it may work for SOME programs, but everything else will be broken.
 _SysenterEntry:
-        cli
-
+        cli             ; Disable interrupts. The kernel doesn't support reentrancy yet.
         push    ecx     ; useresp
         push    edx     ; usereip (return address)
 
-        ; Now construct the interrupt frame
-        ; Bottom 7 fields are unused, just push junk to prepare the actual state
-        times 7 push dword 0
+        ; Now we must construct the SystemCallFrame and give it to the
+        ; system call handler.
+        pushfd
+        push    eax
+        push    ebp
+        push    edi
+        push    esi
+        push    ebx
 
-        ; GPRs
-        pushad
-
-        ; Segment registers
-        push    ds
-        push    es
-        push    fs
-        push    gs
-
-        push    esp                     ; Push the stack as the InterruptStackFrame
+        push    esp                     ; Push the stack as the SystemCallFrame
         call    DragonWareSyscall       ; Call the system call handler
         add     esp,    4               ; Now discard the argument we pushed
 
-        ; Now clean up the stack to only leave the registers we need to return
-        ; from the system call.
-        add     esp,    16      ; Segment registers, not used.
-        popad                   ; Restore the GPRs now with the system call state
-        add     esp,    28      ; Discard stuff that we don't actually use in sysenter/sysexit
+        ; Get whatever the kernel returned into those arguments and restore it
+        ; for the user process. Most importantly, eax holds the return code and
+        ; esi/edi may hold extra return values.
+        pop     ebx
+        pop     esi
+        pop     edi
+        pop     ebp
+        pop     eax
+        popfd
 
-        pop     edx             ; Return address to drop back to
-        pop     ecx             ; User stack to switch to upon return
-
-        sti                     ; Reenable interrupts...
-        sysexit                 ; ...and finally return to userspace!
+        pop     edx                     ; Return address to drop back to
+        pop     ecx                     ; User stack to switch to upon return
+        sti
+        sysexit

--- a/sys/ddk/ia32/sysenter.asm
+++ b/sys/ddk/ia32/sysenter.asm
@@ -48,7 +48,6 @@ EnableSysenter:
 ; typedef struct [[gnu::packed]] _SystemCallFrame {
 ;         u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
 ;         u32 eax;                /* System call number */
-;         u32 eflags;             /* Used for _DWRaiseIOPL only */
 ; } SystemCallFrame;
 ;
 ; We construct it upon entry and then call the system call handler to handle the actual userland system call.
@@ -61,7 +60,6 @@ _SysenterEntry:
 
         ; Now we must construct the SystemCallFrame and give it to the
         ; system call handler.
-        pushfd
         push    eax
         push    ebp
         push    edi
@@ -80,7 +78,6 @@ _SysenterEntry:
         pop     edi
         pop     ebp
         pop     eax
-        popfd
 
         pop     edx                     ; Return address to drop back to
         pop     ecx                     ; User stack to switch to upon return

--- a/sys/ddk/ia32/sysenter.asm
+++ b/sys/ddk/ia32/sysenter.asm
@@ -54,7 +54,6 @@ EnableSysenter:
 ; NOTE: Userland doesn't make use of this code yet. It uses the traditional software interrupt method for now.
 ; Meaning this code here is just a stub for the future, and has not been tested yet.
 _SysenterEntry:
-        cli             ; Disable interrupts. The kernel doesn't support reentrancy yet.
         push    ecx     ; useresp
         push    edx     ; usereip (return address)
 

--- a/sys/ddk/ia32/sysenter.asm
+++ b/sys/ddk/ia32/sysenter.asm
@@ -11,6 +11,7 @@ IA32_SYSENTER_CS        equ     0x174
 IA32_SYSENTER_ESP       equ     0x175
 IA32_SYSENTER_EIP       equ     0x176
 KERNEL_CS_ENTRY         equ     0x08
+USER_DS_SELECTOR        equ     0x23    ; see in _SysenterEntry
 
 bits 32
 section .text
@@ -49,10 +50,7 @@ EnableSysenter:
 ;         u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
 ;         u32 eax;                /* System call number */
 ; } SystemCallFrame;
-;
 ; We construct it upon entry and then call the system call handler to handle the actual userland system call.
-; NOTE: Userland doesn't make use of this code yet. It uses the traditional software interrupt method for now.
-; Meaning this code here is just a stub for the future, and has not been tested yet.
 _SysenterEntry:
         push    ecx     ; useresp
         push    edx     ; usereip (return address)
@@ -68,6 +66,27 @@ _SysenterEntry:
         push    esp                     ; Push the stack as the SystemCallFrame
         call    DragonWareSyscall       ; Call the system call handler
         add     esp,    4               ; Now discard the argument we pushed
+
+        ; So, long story short. I hit a bug while developing this feature that had me completely puzzled for months.
+        ; Today it's 1st of July 2026, I opened the sysenter support pull request on May 10th.
+        ; Now on the bug: If I pressed keys way too fast, or a lot of scrolling was done by the console, suddenly you had a
+        ; general protection fault in a move instruction. The fuck????
+        ; Well, after tons of debugging with gdb, and with the article on osdev.org not being clear enough for this case, I found out
+        ; that the segment selectors were set to 0. Obviously invalid, but I don't touch them anywhere, so even more "what the fuck?".
+        ; Oh, even worse, QEMU didn't reproduce this bug at all. Only Bochs did.
+        ;
+        ; As it turns out, x86 CPUs automatically zero out any of DS/ES/FS/GS registers whose DPL is more privileged than the
+        ; new CPL during the transition to userspace. And even worse, this would only manifest in a very specific, rare scenario where
+        ; the servers would voluntarily yielded causing the scheduler to switch to another thread causing that security protection to kick in
+        ; A DS set to zero is invalid, hence the crash with a #GP.
+        ;
+        ; (Source: Intel developer manuals, volume 3, chapter 6, and https://github.com/torvalds/linux/blob/master/arch/x86/entry/entry_32.S,
+        ; though the latter is far more complicated because it caters to a different internla design)
+        mov     ax,     USER_DS_SELECTOR
+        mov     ds,     ax
+        mov     es,     ax
+        mov     fs,     ax
+        mov     gs,     ax
 
         ; Get whatever the kernel returned into those arguments and restore it
         ; for the user process. Most importantly, eax holds the return code and

--- a/sys/ddk/ia32/tss.h
+++ b/sys/ddk/ia32/tss.h
@@ -12,29 +12,38 @@
 #include <ktypes.h>
 #include <macros.h>
 
+#include "task/process.h"
+
+/* Eight bits per byte, 8192 bytes, thats ~65000 bits, each clear bit
+ * is a port that the current process is allowed to use */
+#define TSS_IOPERM_SIZE (8192)
+
 /* For future readers: Most of these fields will go unused. We
  * don't do hardware task switching because it's slow and inflexible. */
 typedef struct [[gnu::packed]] _TSSEntry {
-        u16 prev_tss, reserved0;
-        u32 esp0;
-        u16 ss0, reserved1;
-        u32 esp1;
-        u16 ss1, reserved2;
-        u32 esp2;
-        u16 ss2, reserved3;
-        u32 cr3;
-        u32 eip;
-        u32 eflags;
-        u32 eax, ecx, edx, ebx;
-        u32 esp, ebp, esi, edi;
-        u16 es, reserved4;
-        u16 cs, reserved5;
-        u16 ss, reserved6;
-        u16 ds, reserved7;
-        u16 fs, reserved8;
-        u16 gs, reserved9;
-        u16 ldt_selector, reserved10;
-        u16 trap, iomap_base;
+        u16  prev_tss, reserved0;
+        u32  esp0;
+        u16  ss0, reserved1;
+        u32  esp1;
+        u16  ss1, reserved2;
+        u32  esp2;
+        u16  ss2, reserved3;
+        u32  cr3;
+        u32  eip;
+        u32  eflags;
+        u32  eax, ecx, edx, ebx;
+        u32  esp, ebp, esi, edi;
+        u16  es, reserved4;
+        u16  cs, reserved5;
+        u16  ss, reserved6;
+        u16  ds, reserved7;
+        u16  fs, reserved8;
+        u16  gs, reserved9;
+        u16  ldt_selector, reserved10;
+        u16  trap, iomap_base;
+        Byte ioperm[TSS_IOPERM_SIZE];
+        Byte terminator; /* Must always be 0xFF */
+
 } TSSEntry;
 
 [[gnu::always_inline]]
@@ -44,3 +53,17 @@ static inline void __ltr(u16 tptr) {
                 "ltr %%ax\n" ::"r"(tptr)
                 : "ax");
 }
+
+/**
+ * @brief Enables access to the I/O ports of the process
+ * by setting up the relevant TSS entry structure.
+ * @since v0.0.2
+ */
+void EnableIOPortsOfProcess(Process *p);
+
+/**
+ * @brief Disables access to the I/O ports owned by process @p p,
+ * usually when that process is blocked and another process is scheduled.
+ * @since v0.0.2
+ */
+void DisableIOPortsOfProcess(Process *p);

--- a/sys/drivers/serial86/com.c
+++ b/sys/drivers/serial86/com.c
@@ -60,7 +60,6 @@ static void WriteSerialChar(void *private, char c) {
                 WriteToSerialPort('\n');
         } else
                 WriteToSerialPort(c);
-
 #else
         UnusedParameter(c);
 #endif

--- a/sys/drivers/serial86/com.c
+++ b/sys/drivers/serial86/com.c
@@ -33,8 +33,6 @@ static void InitSerialConnection(void) {
         outb(COM1_PORT + 4, 0x0B);
 }
 
-static inline void WaitForPort(void) { while (!(inb(COM1_PORT + 5) & 0x20)); }
-
 static inline void WriteToSerialPort(char c) {
         WaitForPort();
         outb(COM1_PORT, (Byte)c);

--- a/sys/drivers/serial86/com.c
+++ b/sys/drivers/serial86/com.c
@@ -33,6 +33,8 @@ static void InitSerialConnection(void) {
         outb(COM1_PORT + 4, 0x0B);
 }
 
+static inline void WaitForPort(void) { while (!(inb(COM1_PORT + 5) & 0x20)); }
+
 static inline void WriteToSerialPort(char c) {
         WaitForPort();
         outb(COM1_PORT, (Byte)c);

--- a/sys/lib/kmalloc.c
+++ b/sys/lib/kmalloc.c
@@ -272,8 +272,6 @@ void *AllocateVirtualPage(void) {
         void     *virtaddr = GetHeapPageAddress();
         uintptr_t addr     = (uintptr_t)virtaddr;
 
-        MarkHeapPageAsUsed(addr);
-
         static u32 flags = PAGE_PRESENT | PAGE_RW;
         if (x86FeatureSupported(X86_PGE)) flags |= PAGE_GLOBAL;
 

--- a/sys/lib/kmalloc.c
+++ b/sys/lib/kmalloc.c
@@ -267,9 +267,12 @@ void *AllocateVirtualPage(void) {
 #endif /* DRAGONWARE_DEBUG_MODE */
                 return NullPointer;
         }
+        extern char _end;
 
         void     *virtaddr = GetHeapPageAddress();
         uintptr_t addr     = (uintptr_t)virtaddr;
+
+        MarkHeapPageAsUsed(addr);
 
         static u32 flags = PAGE_PRESENT | PAGE_RW;
         if (x86FeatureSupported(X86_PGE)) flags |= PAGE_GLOBAL;

--- a/sys/sched/schedule.c
+++ b/sys/sched/schedule.c
@@ -15,7 +15,11 @@
 #include <macros.h>
 #include <panic.h>
 
+#ifdef __i386__
 #include "ddk/ia32/ctxswitch.h"
+#include "ddk/ia32/tss.h"
+#endif /* __i386__ */
+
 #include "task/task.h"
 
 /**
@@ -135,8 +139,12 @@ void ScheduleNext(void) {
                 current_thread = next;
                 if (prev && prev->owner && prev->owner == current_thread->owner)
                         should_switch_process = false;
-                if (current_thread->owner && should_switch_process)
+                if (current_thread->owner && should_switch_process) {
                         SwapProcess(current_thread->owner);
+                        if (prev->owner) DisableIOPortsOfProcess(prev->owner);
+
+                        EnableIOPortsOfProcess(current_thread->owner);
+                }
 
                 SwapThreadStack(&prev->esp, next->esp);
         }

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -84,7 +84,7 @@ InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
                         YieldCurrentThread();
                         break;
                 case SYSCALL_KLOG:
-                        _DWklog((int)regs->ebx, (const char *)regs->ecx);
+                        _DWklog((int)regs->ebx, (const char *)regs->esi);
                         break;
                 case SYSCALL_RAISE_IOPL: {
                         regs->eax = (u32)_DWRaiseIOPL(&regs->eflags);
@@ -92,16 +92,19 @@ InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
                 }
                 case SYSCALL_SEND:
                         regs->eax =
-                                (u32)_DWIPCSend((int)regs->ebx, (Message *)regs->ecx, regs->edx);
+                                (u32)_DWIPCSend((int)regs->ebx, (Message *)regs->esi, regs->edi);
                         break;
                 case SYSCALL_RECEIVE:
-                        regs->eax = (u32)_DWIPCReceive((int)regs->ebx, (Message *)regs->ecx);
+                        regs->eax = (u32)_DWIPCReceive((int)regs->ebx, (Message *)regs->esi);
                         break;
                 case SYSCALL_TICK_SINCE_BOOT: {
                         /* System V ABI says that, for a 64 bit return value, high 32 bits go in
                          * edx, and the low 32 bits go in eax. So we can simply mask out the high 32
                          * bits when assigning to eax and shift down edx by the amount of low
-                         * bits.*/
+                         * bits.
+                         * FIXME: This is broken on sysenter/sysexit instructions (edx must be
+                         * preserved, it holds the return address to userland).
+                         * */
                         u64 ticks = GetTicksSinceBoot();
                         regs->eax = (u32)(ticks & 0xffffffff);
                         regs->edx = (u32)(((u64)ticks) >> 32);
@@ -109,11 +112,11 @@ InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
                 }
                 case SYSCALL_CREATE_OBJECT:
                         regs->eax = (u32)_DWCreateObject((const char *)regs->ebx,
-                                                         (ObjectType)regs->ecx, regs->edx);
+                                                         (ObjectType)regs->esi, regs->edi);
                         break;
                 case SYSCALL_INVOKE_OBJECT:
                         regs->eax =
-                                (u32)_DWInvokeObject((int)regs->ebx, regs->ecx, (void *)regs->edx);
+                                (u32)_DWInvokeObject((int)regs->ebx, regs->esi, (void *)regs->edi);
                         break;
                 case SYSCALL_DELETE_OBJECT:
                         _DWDeleteObject((int)regs->ebx);

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -17,7 +17,6 @@
 #include <macros.h>
 #include <mmutils.h>
 
-#include "ddk/ia32/interrupts.h"
 #include "identify.h"
 #include "ipc.h"
 #include "object.h"
@@ -66,7 +65,7 @@ static Status _DWRaiseIOPL(u32 *eflags) {
                 return STATUS_UNSUPPORTED;
 }
 
-InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
+void DragonWareSyscall(SystemCallFrame *regs) {
         switch (regs->eax) {
                 case SYSCALL_IDENTIFY:
                         SystemIdentifySyscall((SystemIdentify *)regs->ebx);
@@ -107,7 +106,7 @@ InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
                          * */
                         u64 ticks = GetTicksSinceBoot();
                         regs->eax = (u32)(ticks & 0xffffffff);
-                        regs->edx = (u32)(((u64)ticks) >> 32);
+                        // regs->edx = (u32)(((u64)ticks) >> 32);
                         break;
                 }
                 case SYSCALL_CREATE_OBJECT:
@@ -125,13 +124,11 @@ InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs) {
                         regs->eax = (u32)STATUS_BAD_SYSCALL;
                         break;
         }
-        return regs;
 }
 
-InterruptStackFrame *POSIXSyscall(InterruptStackFrame *regs) {
+void POSIXSyscall(SystemCallFrame *regs) {
         LogMessage(LOG_WARNING,
                    "POSIX syscall invoked. POSIX compatibility has not been implemented "
                    "yet.");
         regs->eax = (u32)STATUS_BAD_SYSCALL;
-        return regs;
 }

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -55,6 +55,9 @@ static void _DWklog(int level, const char *msg) {
         klog((LogLevel)level, "%s", buf);
 }
 
+/* TODO: Also note the replacement function (Probably by an I/O object?) */
+[[deprecated(
+        "_DWRaiseIOPL is no longer available, the TSS I/O bitmap has replaced its functionality")]]
 static Status _DWRaiseIOPL(u32 *eflags) {
         /* set the IOPL bit in eflags, but only if the current process possesses the
          * capability to actually use that. */
@@ -86,7 +89,7 @@ void DragonWareSyscall(SystemCallFrame *regs) {
                         _DWklog((int)regs->ebx, (const char *)regs->esi);
                         break;
                 case SYSCALL_RAISE_IOPL: {
-                        regs->eax = (u32)_DWRaiseIOPL(&regs->eflags);
+                        regs->eax = (u32)STATUS_BAD_SYSCALL;
                         break;
                 }
                 case SYSCALL_SEND:

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -17,6 +17,10 @@
 #include <macros.h>
 #include <mmutils.h>
 
+#ifdef __i386__
+#include "ddk/ia32/tss.h"
+#endif /* __i386__ */
+
 #include "identify.h"
 #include "ipc.h"
 #include "object.h"
@@ -55,7 +59,7 @@ static void _DWklog(int level, const char *msg) {
         klog((LogLevel)level, "%s", buf);
 }
 
-/* TODO: Also note the replacement function (Probably by an I/O object?) */
+#if 0
 [[deprecated(
         "_DWRaiseIOPL is no longer available, the TSS I/O bitmap has replaced its functionality")]]
 static Status _DWRaiseIOPL(u32 *eflags) {
@@ -66,6 +70,26 @@ static Status _DWRaiseIOPL(u32 *eflags) {
                 return STATUS_OK;
         } else
                 return STATUS_UNSUPPORTED;
+}
+#endif
+
+static Status _DWRequestPorts(const u16 *port_list, Size list_size) {
+        Process *current = GetCurrentExecutionThread()->owner;
+        if (!(current->flags & PROC_C_IOPL))
+                return STATUS_UNSUPPORTED; /* TODO: Have a STATUS_ACCESS_REJECTED or something */
+
+        if (list_size > MAX_IO_PORTS_PER_PROCESS) return STATUS_BAD_ARGUMENT;
+
+        u16 ports[MAX_IO_PORTS_PER_PROCESS] = {0};
+        if (CopyFromUser(ports, port_list, list_size * sizeof(u16)) != STATUS_OK)
+                return STATUS_BAD_ARGUMENT;
+
+        DisableIOPortsOfProcess(current);
+        for (Size i = 0; i < list_size; i++) current->ioports[i] = ports[i];
+        current->ports_used = (u16)list_size;
+
+        EnableIOPortsOfProcess(current);
+        return STATUS_OK;
 }
 
 void DragonWareSyscall(SystemCallFrame *regs) {
@@ -88,8 +112,8 @@ void DragonWareSyscall(SystemCallFrame *regs) {
                 case SYSCALL_KLOG:
                         _DWklog((int)regs->ebx, (const char *)regs->esi);
                         break;
-                case SYSCALL_RAISE_IOPL: {
-                        regs->eax = (u32)STATUS_BAD_SYSCALL;
+                case SYSCALL_REQUEST_PORTS: {
+                        regs->eax = (u32)_DWRequestPorts((u16 *)regs->ebx, (Size)regs->esi);
                         break;
                 }
                 case SYSCALL_SEND:

--- a/sys/syscall/syscall.h
+++ b/sys/syscall/syscall.h
@@ -15,7 +15,7 @@
 #define SYSCALL_EXIT            (1)
 #define SYSCALL_YIELD           (2)
 #define SYSCALL_KLOG            (3)
-#define SYSCALL_RAISE_IOPL      (4)
+#define SYSCALL_REQUEST_PORTS   (4) /* Replaced the old _DWRaiseIOPL syscall */
 #define SYSCALL_SEND            (5)
 #define SYSCALL_RECEIVE         (6)
 #define SYSCALL_TICK_SINCE_BOOT (7)

--- a/sys/syscall/syscall.h
+++ b/sys/syscall/syscall.h
@@ -25,7 +25,45 @@
 
 /* Only define those for the DragonWare kernel */
 #if __DRAGONWARE_SYS__
+#include <ktypes.h>
+
 #include "ddk/ia32/interrupts.h"
+
+/**
+ * @brief Registers passed in every system call to be modified.
+ * These registers are used to pass arguments in the kernel and store the
+ * return value.
+ * @since v0.0.2
+ */
+typedef struct [[gnu::packed]] _SystemCallFrame {
+        u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
+        u32 eax;                /* System call number */
+        u32 useresp; /* May be used in the future, to copy parameters from the user stack if
+                         necessary. */
+        u32 eflags;  /* Used for _DWRaiseIOPL only */
+} SystemCallFrame;
+
+/**
+ * @brief Converts an @ref InterruptStackFrame to a @ref SystemCallFrame that is used
+ * whenever system calls are triggered by software interrupts (int 0x60).
+ * @since v0.0.2
+ */
+static inline void SyscallFrameFromInterrupt(InterruptStackFrame *iframe, SystemCallFrame *sframe) {
+        sframe->ebx     = iframe->ebx;
+        sframe->esi     = iframe->esi;
+        sframe->edi     = iframe->edi;
+        sframe->ebp     = iframe->ebp;
+        sframe->eax     = iframe->eax;
+        sframe->useresp = iframe->useresp;
+        sframe->eflags  = iframe->eflags;
+}
+
+/**
+ * @brief Returns a @ref SystemCallFrame from an @ref InterruptStackFrame.
+ * @since v0.0.2
+ */
+SystemCallFrame SystemCallFrameFromInterrupt(InterruptStackFrame *frame);
+
 /* Native DragonWare syscall, we implement our own APIs here */
 InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs);
 

--- a/sys/syscall/syscall.h
+++ b/sys/syscall/syscall.h
@@ -38,7 +38,6 @@
 typedef struct [[gnu::packed]] _SystemCallFrame {
         u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
         u32 eax;                /* System call number */
-        u32 eflags;             /* Used for _DWRaiseIOPL only */
 } SystemCallFrame;
 
 /**
@@ -48,12 +47,11 @@ typedef struct [[gnu::packed]] _SystemCallFrame {
  */
 [[gnu::hot]]
 static inline void SyscallFrameFromInterrupt(InterruptStackFrame *iframe, SystemCallFrame *sframe) {
-        sframe->ebx    = iframe->ebx;
-        sframe->esi    = iframe->esi;
-        sframe->edi    = iframe->edi;
-        sframe->ebp    = iframe->ebp;
-        sframe->eax    = iframe->eax;
-        sframe->eflags = iframe->eflags;
+        sframe->ebx = iframe->ebx;
+        sframe->esi = iframe->esi;
+        sframe->edi = iframe->edi;
+        sframe->ebp = iframe->ebp;
+        sframe->eax = iframe->eax;
 }
 
 /* Native DragonWare syscall, we implement our own APIs here */

--- a/sys/syscall/syscall.h
+++ b/sys/syscall/syscall.h
@@ -38,9 +38,7 @@
 typedef struct [[gnu::packed]] _SystemCallFrame {
         u32 ebx, esi, edi, ebp; /* Arguments 0-3 of every system call */
         u32 eax;                /* System call number */
-        u32 useresp; /* May be used in the future, to copy parameters from the user stack if
-                         necessary. */
-        u32 eflags;  /* Used for _DWRaiseIOPL only */
+        u32 eflags;             /* Used for _DWRaiseIOPL only */
 } SystemCallFrame;
 
 /**
@@ -48,26 +46,20 @@ typedef struct [[gnu::packed]] _SystemCallFrame {
  * whenever system calls are triggered by software interrupts (int 0x60).
  * @since v0.0.2
  */
+[[gnu::hot]]
 static inline void SyscallFrameFromInterrupt(InterruptStackFrame *iframe, SystemCallFrame *sframe) {
-        sframe->ebx     = iframe->ebx;
-        sframe->esi     = iframe->esi;
-        sframe->edi     = iframe->edi;
-        sframe->ebp     = iframe->ebp;
-        sframe->eax     = iframe->eax;
-        sframe->useresp = iframe->useresp;
-        sframe->eflags  = iframe->eflags;
+        sframe->ebx    = iframe->ebx;
+        sframe->esi    = iframe->esi;
+        sframe->edi    = iframe->edi;
+        sframe->ebp    = iframe->ebp;
+        sframe->eax    = iframe->eax;
+        sframe->eflags = iframe->eflags;
 }
 
-/**
- * @brief Returns a @ref SystemCallFrame from an @ref InterruptStackFrame.
- * @since v0.0.2
- */
-SystemCallFrame SystemCallFrameFromInterrupt(InterruptStackFrame *frame);
-
 /* Native DragonWare syscall, we implement our own APIs here */
-InterruptStackFrame *DragonWareSyscall(InterruptStackFrame *regs);
+void DragonWareSyscall(SystemCallFrame *frame);
 
 /* POSIX syscall. We currently don't implement them, but may do so for compatibility in the future.
  * You know, porting stuff easier. */
-InterruptStackFrame *POSIXSyscall(InterruptStackFrame *regs);
+void POSIXSyscall(SystemCallFrame *frame);
 #endif /* __DRAGONWARE_SYS__ */

--- a/sys/task/process.c
+++ b/sys/task/process.c
@@ -251,14 +251,11 @@ Process *CreateProcess(ProcessID pid, void *code, Size code_size) {
          * typed in the source "recursive paging trick". */
         ((PageDirectory *)pdmap->virt)[MAX_PD_ENTRIES - 1] = pdmap->phys | PAGE_PRESENT | PAGE_RW;
 
-        p->cr3                = pdmap->phys;
-        p->main_thread        = main_thread;
-        p->pid                = process_id_counter++;
-        p->kernel_stack       = kernel_stack_addr + (2 * FRAME_SIZE);
-        p->queue_size         = 0;
-        p->message_queue_head = NullPointer;
-        p->message_queue_tail = NullPointer;
-        p->next               = NullPointer;
+        p->cr3          = pdmap->phys;
+        p->main_thread  = main_thread;
+        p->pid          = process_id_counter++;
+        p->kernel_stack = kernel_stack_addr + (2 * FRAME_SIZE);
+        p->next         = NullPointer;
         kzeromem(&p->handles, sizeof(HandleTable));
 
         main_thread->owner = p;
@@ -325,18 +322,6 @@ Status DeleteProcess(Process *p) {
                         FreeFrame(pd[i] & PAGE_FRAME_MASK);
                 }
         }
-
-        /* Delete any messages left, as they can't be delivered on time anyways. */
-        MessageQueue *m_iter = p->message_queue_head;
-        while (m_iter) {
-                MessageQueue *next_node = m_iter->next;
-                kfree(m_iter);
-                m_iter = next_node;
-        }
-
-        p->message_queue_head = NullPointer;
-        p->message_queue_tail = NullPointer;
-        p->queue_size         = 0;
 
         UnmapSinglePage(pd_virt);
         MarkTmpMapFree((Size)pd_slot);

--- a/sys/task/process.c
+++ b/sys/task/process.c
@@ -256,6 +256,8 @@ Process *CreateProcess(ProcessID pid, void *code, Size code_size) {
         p->pid          = process_id_counter++;
         p->kernel_stack = kernel_stack_addr + (2 * FRAME_SIZE);
         p->next         = NullPointer;
+        p->ports_used = 0;
+        ZeroMemory(p->ioports);
         kzeromem(&p->handles, sizeof(HandleTable));
 
         main_thread->owner = p;

--- a/sys/task/process.h
+++ b/sys/task/process.h
@@ -16,10 +16,16 @@
 /** @brief Where the user stack will be placed for each process. A high address is chosen to allow
  * the stack to grow freely if necessary in the future. Reminder that the kernel is mapped to
  * 0xC0000000-0xFFFFFFFF. */
-#define DEFAULT_USER_STACK_ADDR (0xBFFF0000)
+#define DEFAULT_USER_STACK_ADDR  (0xBFFF0000)
 
 /** @brief Maximum amount of device handles a device can have open at a given time. */
-#define MAX_DEVICE_HANDLES      (32)
+#define MAX_DEVICE_HANDLES       (32)
+
+/**
+ * @brief Maximum amount of I/O ports that a process can have.
+ * @since v0.0.2
+ */
+#define MAX_IO_PORTS_PER_PROCESS (20)
 
 typedef u32 ProcessID;
 
@@ -41,9 +47,8 @@ typedef struct _Process {
         u32               kernel_stack; /* That one's virtual, use it with SelectKernelStack */
         ProcessID         pid;
         HandleTable       handles;
-        MessageQueue     *message_queue_head;
-        MessageQueue     *message_queue_tail;
-        Size              queue_size;
+        u16               ioports[MAX_IO_PORTS_PER_PROCESS];
+        u16               ports_used;
         ProcessCapability flags;
         struct _Process  *prev, *next;
 } Process;


### PR DESCRIPTION
`sysenter/sysexit` are a pair of instructions introducing low overhead ring 0 entries. From https://wiki.osdev.org/SYSENTER:

"Executes a fast call to a level 0 system procedure or routine. SYSENTER is a companion instruction to SYSEXIT.
The instruction is optimized to provide the maximum performance for system calls from user code running at privilege level 3 to
operating system or executive procedures running at privilege level 0." -- Intel IA-32 (64) programming manual, volume 2B. 

For a microkernel like DragonWare, where system calls are done for almost every task (Because message passing is done using system calls), using this instruction can be very beneficial to performance, reducing the cycles needed to enter the kernel to about half or even more.