### PR TITLE
Patches to support shared memory in DragonWare

### DIFF
--- a/freestanding/common/macros.h
+++ b/freestanding/common/macros.h
@@ -108,6 +108,31 @@
  */
 #define unreachable ((void)__builtin_unreachable())
 
+/*
+ * @brief Shorthand macro to dereference an object that supports reference counting.
+ * @param[in] obj The object to dereference.
+ * @param[in] __LAMBDA__ The function to run on @p obj if no other objects reference it.
+ * @since v0.0.2
+ */
+#define DEREF(obj, __LAMBDA__)           \
+        do {                             \
+                if ((obj)->refcnt > 1) { \
+                        (obj)->refcnt--; \
+                } else {                 \
+                        __LAMBDA__       \
+                }                        \
+                                         \
+        } while (0)
+
+/**
+ * @brief Shorthand macro to reference an object that supports reference counting.
+ * @details This macro is very simple to expand manually, however it forms a nice pair with @ref
+ * DEREF above. That is the only reason it is defined here.
+ * @param[in] obj The object to reference
+ * @since v0.0.2
+ */
+#define REFER(obj)       ((obj)->refcnt++)
+
 /**
  * @brief Preconfigured address of the global framebuffer, usually placed 8MBs before cutoff from
  * the address space.

--- a/sys/iomgr/object.h
+++ b/sys/iomgr/object.h
@@ -59,6 +59,7 @@ typedef enum _SectionObjectOp : unsigned long {
         SECTION_REQUEST, /** << Request the creation of a new section */
         SECTION_MAP,     /** << Map the section in the address space */
         SECTION_SHARE,   /** << Share the section's memory with another process */
+        SECTION_UNMAP,   /** << Unmap the section pointed to, from the current address space  */
 } SectionObjectOp;
 
 /**

--- a/sys/iomgr/section.c
+++ b/sys/iomgr/section.c
@@ -9,8 +9,10 @@
 
 #include "section.h"
 
+#include <assert.h>
 #include <kmalloc.h>
 #include <log.h>
+#include <macros.h>
 #include <mmutils.h>
 #include <panic.h>
 
@@ -18,6 +20,7 @@
 #include "ddk/ia32/vmm.h"
 #include "macros.h"
 #include "mem/frame.h"
+#include "sched/schedule.h"
 
 /* Scans the address space to find a region of at least n_pages that are NOT mapped. Used to find
  * where to map a section. */
@@ -48,9 +51,10 @@ Section *AllocateSection(Size needed_pages, SectionPermissions permissions) {
         scn->address_space = 0; /* Set by the system calls later. */
         scn->permissions   = permissions;
         scn->n_pages       = needed_pages;
+        scn->refcnt        = 0; /* Incremented only during MapSection(). */
         scn->vmbase        = 0;
 
-        ZeroMemory(scn->physframes);
+        ZeroMemory(scn->physframes); /* VERY IMPORTANT, see MapSection below. */
         return scn;
 }
 
@@ -72,40 +76,60 @@ uintptr_t MapSection(Section *section, Bool copy_on_write) {
         Size pages_mapped     = 0;
 
         for (Size i = 0; i < section->n_pages; i++) {
-                uintptr_t pageaddr     = start + (i * PAGE_SIZE);
-                section->physframes[i] = AllocateFrame();
-                if (!section->physframes[i])
-                        goto fail;
-                else
-                        frames_allocated++;
+                Bool      previously_allocated = section->physframes[i] > 0;
+                uintptr_t pageaddr             = start + (i * PAGE_SIZE);
+
+                if (!previously_allocated) {
+                        section->physframes[i] = AllocateFrame();
+                        if (!section->physframes[i])
+                                goto fail;
+                        else
+                                frames_allocated++;
+                }
 
                 if (MapSinglePage(section->physframes[i], pageaddr, flags) != STATUS_OK)
                         goto fail;
                 else {
-                        kzeromem((void *)pageaddr, PAGE_SIZE);
+                        if (!previously_allocated) kzeromem((void *)pageaddr, PAGE_SIZE);
                         pages_mapped++;
                 }
         }
         goto success;
 fail:
-        for (Size i = 0; i < frames_allocated; i++) FreeFrame(section->physframes[i]);
-        for (Size i = 0; i < pages_mapped; i++) UnmapSinglePage(start + (i * PAGE_SIZE));
-        ZeroMemory(section->physframes);
+        DEREF(section, {
+                for (Size i = 0; i < frames_allocated; i++) FreeFrame(section->physframes[i]);
+                for (Size i = 0; i < pages_mapped; i++) UnmapSinglePage(start + (i * PAGE_SIZE));
+                ZeroMemory(section->physframes);
+        });
         return 0;
 
 success:
+        REFER(section);
         section->vmbase = start;
         return start;
 }
 
-void DeleteSection(Section *section) {
-        if (section->n_pages >= MAX_SECTION_FRAMES)
-                return;                /* Probably invalid section, ignore it */
-        if (!section->n_pages) return; /* >> */
+void UnmapSection(Section *section, void *base) {
+        kassert(((uintptr_t)base) > 0);
+        kassert(isaligned((uintptr_t)base, PAGE_SIZE));
 
-        for (Size i = 0; i < section->n_pages; i++) {
-                FreeFrame(section->physframes[i]);
-                UnmapSinglePage(section->vmbase + (i * PAGE_SIZE));
-        }
-        kfree(section);
+        DEREF(section, {
+                if (!section->n_pages) return; /* >> */
+                for (Size i = 0; i < section->n_pages; i++) {
+                        FreeFrame(section->physframes[i]);
+                        uintptr_t addr = ((uintptr_t)base) + (i * PAGE_SIZE);
+                        kzeromem((void *)addr, PAGE_SIZE);
+                        UnmapSinglePage(addr);
+                }
+        });
+}
+
+void DeleteSection(Section *section) {
+        kassert(section->vmbase > 0);
+        if (section->address_space != GetCurrentExecutionThread()->id) return;
+
+        DEREF(section, {
+                UnmapSection(section, (void *)section->vmbase);
+                kfree(section);
+        });
 }

--- a/sys/iomgr/section.h
+++ b/sys/iomgr/section.h
@@ -33,6 +33,7 @@ typedef struct _Section {
         uintptr_t vmbase; /* Where the section starts in virtual memory, used to unmap it later. */
         uintptr_t physframes[MAX_SECTION_FRAMES]; /* Array of frame addresses that are mapped to the
                                                      section's virtual addresses. */
+        int       refcnt; /* Reference count when this section is used by multiple processes. */
 } Section;
 
 /** @brief Flags describing the permissions of a single section. */

--- a/sys/iomgr/section.h
+++ b/sys/iomgr/section.h
@@ -10,9 +10,10 @@
 #pragma once
 
 /* How many bytes of memory can a section occupy. This is to save memory on each section object,
- * because a section object internally also holds address to physical frames. So for 120 frames,
- * each object must hold 256 bytes of raw addresses. */
-#define MAX_SECTION_FRAMES (120)
+ * because a section object internally also holds address to physical frames. Unfortunately at the
+ * moment this limits the amount of memory that can be mapped by a single section object (FIXME:
+ * Address that) */
+#define MAX_SECTION_FRAMES (500)
 
 #include <ktypes.h>
 

--- a/sys/syscall/ipc.c
+++ b/sys/syscall/ipc.c
@@ -64,7 +64,7 @@ Status _DWIPCSend(int handle, Message *m, u32 message_size) {
         if (reply_from >= 0 && reply_from < MAX_OBJ_PER_PROCESS) {
                 Object *replyobj = curr_proc->handles.objlist[reply_from];
 
-                if (replyobj && replyobj->type == OBJ_PORT) {
+                if (replyobj) {
                         HandleTable *target_table = &port->owner->owner->handles;
                         int          new_hdl      = -1;
 


### PR DESCRIPTION
These are some patches I wrote over the past few days to implement shared memory. From some basic tests I wrote, shared memory does seem to work now, though the current workings are very hackish and probably fragile. Debugging a double free at the moment, and I know some shortcomings that need to be addressed, but the general concept works.

We need shared memory for disk drivers and efficient software framebuffer blitting in general. Messages are quite limited by their nature, so sending a 1MB file, for example, will be way too slow and hackish to do with message payloads.