### PR TITLE
Add thread creation support in the microkernel

### DIFF
--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -153,7 +153,6 @@ typedef enum _SectionObjectOp : unsigned long {
 typedef enum _ThreadObjectOp : unsigned long {
         THREAD_CREATE, /** << Create a new thread */
         THREAD_RUN,    /** << Enlist the thread in the scheduler */
-        THREAD_DELETE, /** << Delete the thread and free up any resources by it */
 } ThreadObjectOp;
 
 /**

--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -81,6 +81,16 @@ typedef struct [[gnu::packed]] {
         u32 reserved; /** << Reserved for future expansion */
 } IRQBindingDescriptor;
 
+/**
+ * @brief Data describing thread initial state for use with thread objects.
+ * @since v0.0.2
+ */
+typedef struct [[gnu::packed]] _UserThreadData {
+        void *entry;      /** << Entry point of a thread  */
+        void *stack;      /** << Stack memory for the thread*/
+        void *extra_data; /** << Extra data that will be given to the thread upon execution.*/
+} UserThreadData;
+
 /** @brief Flags describing the permissions of a single section. */
 typedef enum _SectionPermissions : unsigned long {
         SECTION_NONE      = 0x00, /** << Nothing allowed on */
@@ -106,6 +116,7 @@ typedef enum _ObjectType : unsigned long {
         OBJ_DEVICE,      /** << Device manager object */
         OBJ_PORT,        /** << Port (IPC endpoint) object */
         OBJ_SECTION,     /** << Section (Memory management) object */
+        OBJ_THREAD,      /** << Thread (Unit of execution) object */
 } ObjectType;
 
 /**
@@ -134,6 +145,16 @@ typedef enum _SectionObjectOp : unsigned long {
         SECTION_MAP,     /** << Map the section in the address space */
         SECTION_SHARE,   /** << Share the section's memory with another process */
 } SectionObjectOp;
+
+/**
+ * @brief An operation to be performed on a thread object.
+ * @since v0.0.2
+ */
+typedef enum _ThreadObjectOp : unsigned long {
+        THREAD_CREATE, /** << Create a new thread */
+        THREAD_RUN,    /** << Enlist the thread in the scheduler */
+        THREAD_DELETE, /** << Delete the thread and free up any resources by it */
+} ThreadObjectOp;
 
 /**
  * @brief _DWSystemIdentify system call (#0) wrapper

--- a/sys/CMakeLists.txt
+++ b/sys/CMakeLists.txt
@@ -70,6 +70,7 @@ list(APPEND C_SOURCES
      ${CMAKE_CURRENT_SOURCE_DIR}/iomgr/section.c
      ${CMAKE_CURRENT_SOURCE_DIR}/iomgr/object.c
      ${CMAKE_CURRENT_SOURCE_DIR}/iomgr/node.c
+     ${CMAKE_CURRENT_SOURCE_DIR}/iomgr/thread.c
      ${CMAKE_CURRENT_SOURCE_DIR}/task/task.c
      ${CMAKE_CURRENT_SOURCE_DIR}/task/process.c
      ${CMAKE_CURRENT_SOURCE_DIR}/task/message.c

--- a/sys/ddk/ia32/ctxswitch.c
+++ b/sys/ddk/ia32/ctxswitch.c
@@ -9,10 +9,8 @@
 
 #include "ctxswitch.h"
 
-#include "gdt.h"
 #include "vmm.h"
 
 void SwapProcess(Process *new) {
         SetPageDirectory(new->main_thread->owner->cr3);
-        SelectKernelStack(new->main_thread->owner->kernel_stack);
 }

--- a/sys/ddk/ia32/ctxswitch.c
+++ b/sys/ddk/ia32/ctxswitch.c
@@ -8,9 +8,10 @@
  ***********************************************************************/
 
 #include "ctxswitch.h"
+#include <log.h>
 
 #include "vmm.h"
 
 void SwapProcess(Process *new) {
-        SetPageDirectory(new->main_thread->owner->cr3);
+        SetPageDirectory(new->cr3);
 }

--- a/sys/ddk/ia32/exception.c
+++ b/sys/ddk/ia32/exception.c
@@ -9,11 +9,13 @@
 
 #include "exception.h"
 
+#include <ktypes.h>
+#include <power.h>
+
 #include "gdt.h"
 #include "interrupts.h"
 #include "log.h"
 #include "panic.h"
-#include "power.h"
 #include "sched/schedule.h"
 #include "task/process.h"
 #include "task/task.h"
@@ -27,15 +29,19 @@ static void _DWUserException(InterruptStackFrame *stack_frame) {
                 case I_GPF:
                 case I_PF:
                 default: {
-                        u32     cr2  = GetFaultingAddress();
-                        Thread *curr = GetCurrentExecutionThread();
-                        curr->state  = THREAD_TERMINATED;
+                        u32      cr2  = GetFaultingAddress();
+                        Process *curr = GetCurrentExecutionThread()->owner;
                         LogMessage(
                                 LOG_ERROR,
                                 "Process %u exception 0x%x, EFLAGS 0x%x, ERRCODE 0x%x EIP %p, ESP "
                                 "%p CR2 0x%x",
-                                curr->owner->pid, stack_frame->int_no, stack_frame->eflags,
+                                curr->pid, stack_frame->int_no, stack_frame->eflags,
                                 stack_frame->err_code, stack_frame->eip, stack_frame->useresp, cr2);
+
+                        Status del = DeleteProcess(curr);
+                        if (unlikely(del != STATUS_OK))
+                                LogMessage(LOG_ERROR, "Deleting process %u failed (%s)", curr->pid,
+                                           StatusCodeToString(del));
 
                         /* TODO: If it's a server, it must be restarted, otherwise the system may be
                          * unable to *serve* applications that depended on it */

--- a/sys/ddk/ia32/gdt_x86.asm
+++ b/sys/ddk/ia32/gdt_x86.asm
@@ -14,11 +14,8 @@ global FlushGDT
 ; performs a far jump into the new kernel code segments,
 ; then reloads the segment registers with their appropriate kernel
 ; values for data and returns.
-;
-; GPRs are preserved.
 FlushGDT:
 	mov eax, [esp+4]
-	pushad
 	lgdt [eax]
 	jmp 0x08:.NewCS
 .NewCS:
@@ -26,8 +23,5 @@ FlushGDT:
 	mov ds, ax
 	mov es, ax
 	mov ss, ax
-	mov fs, ax
-	mov gs, ax
 	
-	popad
 	ret

--- a/sys/ddk/ia32/vmm.c
+++ b/sys/ddk/ia32/vmm.c
@@ -166,6 +166,18 @@ Status MapSinglePage(uintptr_t phys, uintptr_t virt, u32 flags) {
 }
 
 void UnmapSinglePage(uintptr_t virt) {
+        /* Unmapped address, nothing to do, but still, I'm printing a debug log here in case
+         * something slips by */
+        if (!IsVirtualPageMapped(virt)) {
+#ifdef DRAGONWARE_DEBUG_MODE
+                LogMessage(LOG_WARNING,
+                           "Attempting to unmap page 0x%x from address space while "
+                           "IsVirtualPageMapped returned false!",
+                           virt);
+#endif /* DRAGONWARE_DEBUG_MODE */
+                return;
+        }
+
         const Size pdindex = PD_INDEX(virt);
         const Size ptindex = PT_INDEX(virt);
 

--- a/sys/iomgr/object.c
+++ b/sys/iomgr/object.c
@@ -39,23 +39,27 @@ void DeleteObject(Object *obj) {
                 return;
         }
 
-        switch (obj->type) {
-                case OBJ_PORT:
-                        DeletePort((Port *)obj->data);
-                        break;
-                case OBJ_SECTION:
-                        DeleteSection((Section *)obj->data);
-                        break;
-                case OBJ_THREAD:
-                        DeleteThread(obj->data);
-                        break;
-                case OBJ_DEVICE: /* The device manager should not have nodes deleted. */
-                case OBJ_UNKNOWN:
-                default:
-                        break;
+        if (likely(obj->data)) {
+                switch (obj->type) {
+                        case OBJ_PORT:
+                                DeletePort((Port *)obj->data);
+                                break;
+                        case OBJ_SECTION:
+                                DeleteSection((Section *)obj->data);
+                                break;
+                        case OBJ_THREAD:
+                                DeleteThread(obj->data);
+                                break;
+                        case OBJ_DEVICE: /* The device manager should not have nodes deleted. */
+                        case OBJ_UNKNOWN:
+                        default:
+                                break;
+                }
         }
+
         kfree(obj);
 }
+
 int AppendToHandleTable(HandleTable *table, Object *obj) {
         u32 free_mask = ~table->valid_bitmap;
         if (free_mask == 0) return -1;

--- a/sys/iomgr/object.c
+++ b/sys/iomgr/object.c
@@ -39,13 +39,15 @@ void DeleteObject(Object *obj) {
                 return;
         }
 
-        if (obj->refcnt > 0) obj->refcnt = 0;
         switch (obj->type) {
                 case OBJ_PORT:
                         DeletePort((Port *)obj->data);
                         break;
                 case OBJ_SECTION:
                         DeleteSection((Section *)obj->data);
+                        break;
+                case OBJ_THREAD:
+                        DeleteThread(obj->data);
                         break;
                 case OBJ_DEVICE: /* The device manager should not have nodes deleted. */
                 case OBJ_UNKNOWN:

--- a/sys/iomgr/object.h
+++ b/sys/iomgr/object.h
@@ -35,6 +35,7 @@ typedef enum _ObjectType : unsigned long {
         OBJ_DEVICE,
         OBJ_PORT,
         OBJ_SECTION,
+        OBJ_THREAD,
 } ObjectType;
 
 /** @brief An operation to be performed on a device object */
@@ -59,6 +60,16 @@ typedef enum _SectionObjectOp : unsigned long {
         SECTION_MAP,     /** << Map the section in the address space */
         SECTION_SHARE,   /** << Share the section's memory with another process */
 } SectionObjectOp;
+
+/**
+ * @brief An operation to be performed on a thread object.
+ * @since v0.0.2
+ */
+typedef enum _ThreadObjectOp : unsigned long {
+        THREAD_CREATE,
+        THREAD_RUN,
+        THREAD_DELETE
+} ThreadObjectOp;
 
 /**
  * @brief A kernel-allocated object used by processes to interact with the kernel API.

--- a/sys/iomgr/object.h
+++ b/sys/iomgr/object.h
@@ -68,7 +68,6 @@ typedef enum _SectionObjectOp : unsigned long {
 typedef enum _ThreadObjectOp : unsigned long {
         THREAD_CREATE,
         THREAD_RUN,
-        THREAD_DELETE
 } ThreadObjectOp;
 
 /**

--- a/sys/iomgr/thread.c
+++ b/sys/iomgr/thread.c
@@ -49,6 +49,8 @@ void *CreateThread(void (*entryaddr)(void), void *stack) {
         uintptr_t phys_stack_2 = AllocateFrame();
         uintptr_t stackaddr    = GetNextKernelStackAddress() + (2 * PAGE_SIZE);
 
+        if (!stackaddr) return NullPointer;
+        
         if (!phys_stack_1 || !phys_stack_2) goto bad;
         if (MapSinglePage(phys_stack_2, stackaddr - PAGE_SIZE, PAGE_PRESENT | PAGE_RW) != STATUS_OK)
                 goto bad;

--- a/sys/iomgr/thread.c
+++ b/sys/iomgr/thread.c
@@ -37,27 +37,41 @@ static uintptr_t GetNextKernelStackAddress(void) {
                 current_addr += (2 * PAGE_SIZE);
         }
 
-        FatalError("Not enough virtual memory left for the kernel stacks.");
+        return 0;
 }
 
 void *CreateThread(void (*entryaddr)(void), void *stack) {
+        /* Declaring it on top otherwise the bitch called clangd says "Variable
+         * 't' is used uninitialized whenever 'if' condition is true" in the checks below */
+        Thread *t = NullPointer;
+
         uintptr_t phys_stack_1 = AllocateFrame();
         uintptr_t phys_stack_2 = AllocateFrame();
         uintptr_t stackaddr    = GetNextKernelStackAddress() + (2 * PAGE_SIZE);
-        MapSinglePage(phys_stack_2, stackaddr - PAGE_SIZE, PAGE_PRESENT | PAGE_RW);
-        MapSinglePage(phys_stack_1, stackaddr - (2 * PAGE_SIZE), PAGE_PRESENT | PAGE_RW);
 
-        Thread *t = AllocateUserThread(entryaddr, (uintptr_t)stack, stackaddr);
-        if (!t) return NullPointer;
+        if (!phys_stack_1 || !phys_stack_2) goto bad;
+        if (MapSinglePage(phys_stack_2, stackaddr - PAGE_SIZE, PAGE_PRESENT | PAGE_RW) != STATUS_OK)
+                goto bad;
+        if (MapSinglePage(phys_stack_1, stackaddr - (2 * PAGE_SIZE), PAGE_PRESENT | PAGE_RW) !=
+            STATUS_OK)
+                goto bad;
+
+        t = AllocateUserThread(entryaddr, (uintptr_t)stack, stackaddr);
+        if (!t) goto bad;
 
         t->owner = GetCurrentExecutionThread()->owner;
         return t;
+
+bad:
+        if (phys_stack_1) FreeFrame(phys_stack_1);
+        if (phys_stack_2) FreeFrame(phys_stack_2);
+        UnmapSinglePage(stackaddr - PAGE_SIZE);
+        UnmapSinglePage(stackaddr - (2 * PAGE_SIZE));
+        if (t) DeleteThread(t);
+
+        return NullPointer;
 }
 
-/**
- * @brief Appends @p thread to the scheduler list, preparing it for execution.
- * @param[in] thread The thread to use. Must not be a @ref NullPointer
- */
 [[gnu::nonnull]]
 void RunThread(Object *thread) {
         AddThreadToScheduler(thread->data);

--- a/sys/iomgr/thread.c
+++ b/sys/iomgr/thread.c
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * FILE: thread.c
+ * PURPOSE: Thread object management implementation
+ * PROJECT: DragonWare Kernel
+ * DATE: 07-2026
+ * AUTHOR: Aggelos Tselios <aggelostselios777@gmail.com>
+ * LICENSE: GPL-3.0-or-later (https://spdx.org/licenses/GPL-3.0-or-later.html)
+ ***********************************************************************/
+
+#include "thread.h"
+
+#include <ktypes.h>
+#include <log.h>
+#include <panic.h>
+
+#include "ddk/ia32/paging.h"
+#include "ddk/ia32/vmm.h"
+#include "iomgr/object.h"
+#include "mem/frame.h"
+#include "sched/schedule.h"
+#include "task/process.h"
+#include "task/task.h"
+
+/* Returns a virtual address that is free to map the kernel stack for a process contiguously. Panics
+ * if it can't find one. Copied verbatim from sys/task/process.c, so we probably need to apply some
+ * DRY here. (<---- FIXME) */
+static uintptr_t GetNextKernelStackAddress(void) {
+        uintptr_t current_addr = KERNEL_STACK_BASE;
+
+        /* The kernel stack is two pages wide for each process, which is why we need two contiguous
+         * pages available. */
+        while (current_addr + (2 * PAGE_SIZE) <= KERNEL_STACK_END) {
+                if (!IsVirtualPageMapped(current_addr) &&
+                    !IsVirtualPageMapped(current_addr + PAGE_SIZE)) {
+                        return current_addr;
+                }
+                current_addr += (2 * PAGE_SIZE);
+        }
+
+        FatalError("Not enough virtual memory left for the kernel stacks.");
+}
+
+void *CreateThread(void (*entryaddr)(void), void *stack) {
+        uintptr_t phys_stack_1 = AllocateFrame();
+        uintptr_t phys_stack_2 = AllocateFrame();
+        uintptr_t stackaddr    = GetNextKernelStackAddress() + (2 * PAGE_SIZE);
+        MapSinglePage(phys_stack_2, stackaddr - PAGE_SIZE, PAGE_PRESENT | PAGE_RW);
+        MapSinglePage(phys_stack_1, stackaddr - (2 * PAGE_SIZE), PAGE_PRESENT | PAGE_RW);
+
+        Thread *t = AllocateUserThread(entryaddr, (uintptr_t)stack, stackaddr);
+        if (!t) return NullPointer;
+
+        t->owner = GetCurrentExecutionThread()->owner;
+        return t;
+}
+
+/**
+ * @brief Appends @p thread to the scheduler list, preparing it for execution.
+ * @param[in] thread The thread to use. Must not be a @ref NullPointer
+ */
+[[gnu::nonnull]]
+void RunThread(Object *thread) {
+        AddThreadToScheduler(thread->data);
+}

--- a/sys/iomgr/thread.c
+++ b/sys/iomgr/thread.c
@@ -47,10 +47,10 @@ void *CreateThread(void (*entryaddr)(void), void *stack) {
 
         uintptr_t phys_stack_1 = AllocateFrame();
         uintptr_t phys_stack_2 = AllocateFrame();
-        uintptr_t stackaddr    = GetNextKernelStackAddress() + (2 * PAGE_SIZE);
-
+        uintptr_t stackaddr    = GetNextKernelStackAddress();
         if (!stackaddr) return NullPointer;
         
+        stackaddr +=  + (2 * PAGE_SIZE);
         if (!phys_stack_1 || !phys_stack_2) goto bad;
         if (MapSinglePage(phys_stack_2, stackaddr - PAGE_SIZE, PAGE_PRESENT | PAGE_RW) != STATUS_OK)
                 goto bad;

--- a/sys/iomgr/thread.h
+++ b/sys/iomgr/thread.h
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * FILE: thread.h
+ * PURPOSE: Thread object related exports
+ * PROJECT: DragonWare Kernel
+ * DATE: 07-2026
+ * AUTHOR: Aggelos Tselios <aggelostselios777@gmail.com>
+ * LICENSE: GPL-3.0-or-later (https://spdx.org/licenses/GPL-3.0-or-later.html)
+ ***********************************************************************/
+
+#pragma once
+
+#include <ktypes.h>
+
+#include "iomgr/object.h"
+
+/**
+ * @brief Data describing thread initial state for use with thread objects.
+ * @since v0.0.2
+ */
+typedef struct [[gnu::packed]] _UserThreadData {
+        void *entry; /** << Entry point of a thread  */
+        void *stack; /** << Stack memory for the thread*/
+        void *extra_data; /** << Extra data that will be given to the thread upon execution.*/
+} UserThreadData;
+
+/**
+ * @brief Create a new thread object, setting up the @p stack for it and, when scheduled, begin
+ * execution in @p entryaddr for it.
+ *
+ * @param[in] entryaddr Thread entry point. Must be a pointer to a function where execution will
+ * begin.
+ * @param[in] stack Address of the stack to load for the thread. Cannot be a @ref NullPointer
+ * @note The resulting constructed thread is NOT put in the scheduler list.
+ * @returns A thread object as internal data for a @ref Object, or @ref NullPointer on failure.
+ */
+[[gnu::nonnull]]
+void *CreateThread(void (*entryaddr)(void), void *stack);
+
+/**
+ * @brief Appends @p thread to the scheduler list, preparing it for execution.
+ * @param[in] thread The thread to use. Must not be a @ref NullPointer
+ */
+[[gnu::nonnull]]
+void RunThread(Object *thread);

--- a/sys/sched/schedule.c
+++ b/sys/sched/schedule.c
@@ -15,6 +15,8 @@
 #include <macros.h>
 #include <panic.h>
 
+#include "ddk/ia32/gdt.h"
+
 #ifdef __i386__
 #include "ddk/ia32/ctxswitch.h"
 #include "ddk/ia32/tss.h"
@@ -146,6 +148,9 @@ void ScheduleNext(void) {
                         EnableIOPortsOfProcess(current_thread->owner);
                 }
 
+                /* Kernel threads have kernel_stack set to zero by default, so we mustn't switch to
+                 * them. */
+                if (next->kernel_stack > 0) SelectKernelStack(next->kernel_stack);
                 SwapThreadStack(&prev->esp, next->esp);
         }
 }

--- a/sys/syscall/object.c
+++ b/sys/syscall/object.c
@@ -246,9 +246,6 @@ static Status HandleThreadObjectRequest(int handle, Object *obj, ThreadObjectOp 
                         } else
                                 return STATUS_BAD_ARGUMENT;
                 }
-                case THREAD_DELETE:
-                        /* TODO */
-                        return STATUS_UNSUPPORTED;
                 default:
                         return STATUS_BAD_ARGUMENT;
         }

--- a/sys/syscall/object.c
+++ b/sys/syscall/object.c
@@ -25,6 +25,7 @@
 #include "iomgr/object.h"
 #include "iomgr/port.h"
 #include "iomgr/section.h"
+#include "iomgr/thread.h"
 #include "sched/schedule.h"
 #include "syscall/usercopy.h"
 #include "task/process.h"
@@ -223,6 +224,34 @@ static Status HandleSectionObjectRequest(int handle, Object *obj, SectionObjectO
         return STATUS_OK;
 }
 
+static Status HandleThreadObjectRequest(int handle, Object *obj, ThreadObjectOp op, void *arg) {
+        UnusedParameter(handle);
+        switch (op) {
+                case THREAD_CREATE: {
+                        /* already created thread, avoid allocating twice */
+                        if (obj->data) return STATUS_BAD_ARGUMENT;
+                        UserThreadData data;
+                        if (CopyFromUser(&data, arg, sizeof(UserThreadData)) != STATUS_OK)
+                                return STATUS_BAD_ARGUMENT;
+
+                        obj->data = CreateThread((ThreadEntryPoint)data.entry, data.stack);
+                        return (obj->data) ? STATUS_OK : STATUS_BAD;
+                }
+                case THREAD_RUN: {
+                        if (obj && obj->data) {
+                                RunThread(obj);
+                                return STATUS_OK;
+                        } else
+                                return STATUS_BAD_ARGUMENT;
+                }
+                case THREAD_DELETE:
+                        /* TODO */
+                        return STATUS_UNSUPPORTED;
+                default:
+                        return STATUS_BAD_ARGUMENT;
+        }
+}
+
 int _DWCreateObject(const char *name, ObjectType type, u32 permissions) {
         UnusedParameter(permissions);
 
@@ -269,6 +298,8 @@ Status _DWInvokeObject(int handle, unsigned long op, void *argptr) {
                         return HandlePortObjectRequest(handle, target, op, argptr);
                 case OBJ_SECTION:
                         return HandleSectionObjectRequest(handle, target, op, argptr);
+                case OBJ_THREAD:
+                        return HandleThreadObjectRequest(handle, target, op, argptr);
                 default:
                         return STATUS_BAD_ARGUMENT;
         }

--- a/sys/syscall/object.c
+++ b/sys/syscall/object.c
@@ -234,6 +234,8 @@ static Status HandleThreadObjectRequest(int handle, Object *obj, ThreadObjectOp 
                         if (CopyFromUser(&data, arg, sizeof(UserThreadData)) != STATUS_OK)
                                 return STATUS_BAD_ARGUMENT;
 
+                        if (!data.stack || !data.entry) return STATUS_BAD_ARGUMENT;
+                        
                         obj->data = CreateThread((ThreadEntryPoint)data.entry, data.stack);
                         return (obj->data) ? STATUS_OK : STATUS_BAD;
                 }

--- a/sys/task/process.c
+++ b/sys/task/process.c
@@ -248,7 +248,6 @@ Process *CreateProcess(ProcessID pid, void *code, Size code_size) {
         p->cr3          = pdmap->phys;
         p->main_thread  = main_thread;
         p->pid          = process_id_counter++;
-        p->kernel_stack = kernel_stack_addr + (2 * FRAME_SIZE);
         p->next         = NullPointer;
         p->ports_used   = 0;
         ZeroMemory(p->ioports);

--- a/sys/task/process.c
+++ b/sys/task/process.c
@@ -283,7 +283,10 @@ Status DeleteProcess(Process *p) {
         p->next = NullPointer;
         p->prev = NullPointer;
 
-        for (int i = 0; i < MAX_OBJ_PER_PROCESS; i++) DeleteFromHandleTable(&p->handles, i);
+        for (int i = 0; i < MAX_OBJ_PER_PROCESS; i++) {
+                Object *ob = DeleteFromHandleTable(&p->handles, i);
+                if (ob) DeleteObject(ob);
+        }
 
         static const char *no_vmem_msg = "Not enough virtual memory left for a temporary mapping";
         int                pd_slot     = FindFreeTmpMapSlot();
@@ -298,6 +301,7 @@ Status DeleteProcess(Process *p) {
         MapSinglePage(p->cr3, pd_virt, PAGE_PRESENT | PAGE_RW);
         PageDirectory *pd = (PageDirectory *)pd_virt;
 
+        p->main_thread->state = THREAD_TERMINATED;
         for (unsigned int i = 0; i < KERNEL_PD_INDEX; i++) {
                 if (pd[i] & PAGE_PRESENT) {
                         Status mapstatus = MapSinglePage(pd[i] & PAGE_FRAME_MASK, pt_virt,

--- a/sys/task/process.c
+++ b/sys/task/process.c
@@ -39,12 +39,6 @@
 /* Where do flat binaries expect execution to start (In other words, where their origin is set) */
 #define FLAT_BINARY_DEFAULT_ENTRY ((ThreadEntryPoint)(0x100000))
 
-/* Beginning of all kernel stacks in virtual memory. */
-#define KERNEL_STACK_BASE         (0xE0000000)
-
-/* Last address we can map as a kernel stack for a process before panicking. */
-#define KERNEL_STACK_END          (0xEFFF0000)
-
 /* Size of the stack in pages. Each page = 4096 bytes, so 16KBs of stack per process. */
 #define USER_STACK_SIZE_PAGES     (4)
 

--- a/sys/task/process.h
+++ b/sys/task/process.h
@@ -50,7 +50,6 @@ typedef enum _ProcessCapability {
 typedef struct _Process {
         Thread           *main_thread;
         u32               cr3;          /* WARNING: Physical address */
-        u32               kernel_stack; /* That one's virtual, use it with SelectKernelStack */
         ProcessID         pid;
         HandleTable       handles;
         u16               ioports[MAX_IO_PORTS_PER_PROCESS];

--- a/sys/task/process.h
+++ b/sys/task/process.h
@@ -13,6 +13,12 @@
 #include "iomgr/object.h"
 #include "task.h"
 
+/** @brief Beginning of all kernel stacks in virtual memory. */
+#define KERNEL_STACK_BASE         (0xE0000000)
+
+/** @brief Last address we can map as a kernel stack for a process before panicking. */
+#define KERNEL_STACK_END          (0xEFFF0000)
+
 /** @brief Where the user stack will be placed for each process. A high address is chosen to allow
  * the stack to grow freely if necessary in the future. Reminder that the kernel is mapped to
  * 0xC0000000-0xFFFFFFFF. */

--- a/sys/task/task.c
+++ b/sys/task/task.c
@@ -109,6 +109,7 @@ Thread *AllocateUserThread(ThreadEntryPoint entry, uintptr_t useresp, uintptr_t 
         /* Now the thread frame is ready, set it up */
         t->esp = t->stack_top = (u32)esp;
         t->state              = THREAD_READY;
+        t->kernel_stack       = kernel_stack;
         t->owner              = NullPointer; /* Set by CreateProcess */
         t->next               = NullPointer;
         t->pl                 = THREAD_USER;

--- a/sys/task/task.h
+++ b/sys/task/task.h
@@ -57,6 +57,7 @@ typedef enum _ThreadPriorityLevel : signed short {
 
 typedef struct _Thread {
         u32 esp;       /* The current stack pointer */
+        uintptr_t kernel_stack; /* Only valid for unprivileged (non-kernel) threads. */
         u32 trapframe; /* Trap frame. Contains the frame required to return into userspace (iret
                           frame in other words) */
         u32 stack_top; /* We keep a pointer to the original stack so we can just reset threads in


### PR DESCRIPTION
We need multithreading support to implement any decent disk driver (It is, actually, the only roadblock I've hit so far while trying out a prototype for it). In addition, at some point, we will need to have multiple units of execution per address space (Fancy way to say "apps that do many things at once") and I think it is a good addition to have as we are reaching v0.0.2. It also exposed an assumption I had been using so far, that one process means one thread. Seems like I've stripped it away, but maybe it's still hiding somewhere.

Threads are, like many other things (such as sections and ports), a kernel object. It was a deliberate decision because I want to keep the system call table on the smaller side.

I have no idea if they actually work. I only ran a quick test with an infinite loop binary, they seem to work well, but we will also need locking mechanisms in `dwuser`/`dlibc` etc. Let's see how it goes.

Signed-off-by: Aggelos Tselios <aggelostselios777@gmail.com>