### PR TITLE
tree: Drop `_DWklog` system call from kernel and userland

### DIFF
--- a/base/ps2kbd/port.h
+++ b/base/ps2kbd/port.h
@@ -59,13 +59,8 @@ static inline void FlushControllerData(void) {
  * cleared. A shortcut for WaitForInputBuffer and outb() synchronization.
  */
 static inline void i8042Write(Byte value) {
-        if (WaitForInputBuffer() != STATUS_OK) {
-#ifdef DRAGONWARE_DEBUG_MODE
-                _DWklog(LOG_ERROR,
-                        "i8042 input buffer timeout during i8042Write(), not submitting write.");
-#endif /* DRAGONWARE_DEBUG_MODE */
+        if (WaitForInputBuffer() != STATUS_OK)
                 return;
-        }
         outb(PS2_PORT_COMMAND, value);
 }
 
@@ -74,14 +69,8 @@ static inline void i8042Write(Byte value) {
  * Same as @ref i8042Write but uses a different port.
  */
 static inline void i8042WriteData(Byte value) {
-        if (WaitForInputBuffer() != STATUS_OK) {
-#ifdef DRAGONWARE_DEBUG_MODE
-                _DWklog(LOG_ERROR,
-                        "i8042 input buffer timeout during i8042WriteData(), not submitting "
-                        "write.");
-#endif /* DRAGONWARE_DEBUG_MODE */
+        if (WaitForInputBuffer() != STATUS_OK)
                 return;
-        }
         outb(PS2_PORT_DATA, value);
 }
 
@@ -90,12 +79,7 @@ static inline void i8042WriteData(Byte value) {
  * the controller verifies that the output buffer is full.
  */
 static inline Byte i8042Read(void) {
-        if (WaitForOutputBuffer() != STATUS_OK) {
-#ifdef DRAGONWARE_DEBUG_MODE
-                _DWklog(LOG_ERROR,
-                        "i8042 output buffer timeout during i8042Write(), returning 0x00.");
-#endif /* DRAGONWARE_DEBUG_MODE */
+        if (WaitForOutputBuffer() != STATUS_OK)
                 return 0x00;
-        }
         return inb(PS2_PORT_DATA);
 }

--- a/base/ps2kbd/ps2kbd.c
+++ b/base/ps2kbd/ps2kbd.c
@@ -103,12 +103,8 @@ static Status Perform8042SelfTest(void) {
         Byte result = i8042Read();
 
         /* Only 0x55 is considered a pass value, any other value is an error */
-        if (result != 0x55) {
-#ifdef DRAGONWARE_DEBUG_MODE
-                _DWklog(LOG_ERROR, "i8042 controller self test failed (result != 0x55)!");
-#endif /* DRAGONWARE_DEBUG_MODE */
+        if (result != 0x55)
                 return STATUS_BAD;
-        }
         return STATUS_OK;
 }
 
@@ -116,7 +112,6 @@ static Status Perform8042SelfTest(void) {
  * @brief Attempts to detect the presence of an i8042 controller in the system.
  * @returns STATUS_OK if the controller is present, STATUS_BAD if it could not be detected or/and is
  * faulty.
- * @note This also logs messages in the kernel log buffer.
  */
 static Status Probe8042Controller(void) {
         /* DragonWare doesn't support ACPI, so we'll have to test the old fashioned way. */
@@ -160,18 +155,12 @@ static Status Probe8042Controller(void) {
          * configuration we just did */
         i8042WriteData(PS2_RESET_EVERYTHING);
         Byte response = i8042Read();
-        if (response != 0xFA) {
-                _DWklog(LOG_DEBUG, "Keyboard did not ACK reset request");
+        if (response != 0xFA)
                 return STATUS_BAD;
-        }
 
         Byte pass = i8042Read();
-        if (pass != 0xAA) {
-#ifdef DRAGONWARE_DEBUG_MODE
-                _DWklog(LOG_ERROR, "Keyboard failed reset self-test.");
-#endif
+        if (pass != 0xAA)
                 return STATUS_BAD;
-        }
 
         return STATUS_OK;
 }
@@ -183,10 +172,8 @@ int main(void) {
         u16 ports_needed[] = {PS2_PORT_STATUS, PS2_PORT_DATA};
         if (_DWRequestPorts(ports_needed, 2) != STATUS_OK) return -1;
 
-        if (Probe8042Controller() != STATUS_OK) {
-                _DWklog(LOG_ERROR, "Unable to probe i8042 controller. Keyboard will be disabled.");
+        if (Probe8042Controller() != STATUS_OK)
                 return -0xDD;
-        }
 
         i8042WriteData(PS2_ENABLE_SCANNING);
 

--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -213,7 +213,8 @@ void _cdecl _DWYield(void);
  * @param msg The message to write to the kernel logs. Must not be NULL.
  * @sa LogLevel
  */
-[[gnu::nonnull]]
+[[gnu::nonnull, deprecated("_DWklog is no longer available as a system call as the task of logging "
+                           "messages is left up to userland")]]
 void _cdecl _DWklog(LogLevel level, const char *msg);
 
 /**

--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -15,6 +15,7 @@
 #define SYSCALL_IDENTIFY         (0)
 #define SYSCALL_EXIT             (1)
 #define SYSCALL_YIELD            (2)
+#define SYSCALL_SYSTEM_QUERY     (3)
 #define SYSCALL_REQUEST_PORTS    (4)
 #define SYSCALL_SEND             (5)
 #define SYSCALL_RECEIVE          (6)
@@ -23,7 +24,6 @@
 #define SYSCALL_INVOKE_OBJECT    (9)
 #define SYSCALL_DELETE_OBJECT    (10)
 #define SYSCALL_TRANSLATE_HANDLE (11)
-#define SYSCALL_SYSTEM_QUERY     (12)
 
 #include "cabi.h"
 #include "cppsupport.h"
@@ -204,6 +204,18 @@ void _cdecl noreturn _DWExit(void);
 void _cdecl _DWYield(void);
 
 /**
+ * @brief Queries a system value @p key and returns the kernel-configured value for it. If extra
+ * data needs to be copied, it is copied to the memory address pointed to by @p store (Currently
+ * unused as of v0.0.2). (System call #3)
+ * @param key The system value to query. See @ref SystemQuery
+ * @param[out] store Pointer to memory where extra data will be copied, if needed, otherwise
+ * ignored.
+ * @returns The value of @p key as a system value upon the time of the call.
+ * @since v0.0.2
+ */
+int _cdecl _DWSystemQuery(SystemQuery key, void *store);
+
+/**
  * @brief _DWRequestPorts system call (#4) wrapper.
  * @details This function requests from the kernel permission to directly read from the I/O ports
  * specified inside @p port_list, an array of 16-bit integers of ports that the process needs to
@@ -306,17 +318,6 @@ void _DWDeleteObject(int handle);
  * free slots to store the handle to. STATUS_BAD if the copy to @p save failed.
  */
 Status _DWTranslateHandle(ProcessID process_id, int handle, int *save);
-
-/**
- * @brief Queries a system value @p key and returns the kernel-configured value for it. If extra
- * data needs to be copied, it is copied to the memory address pointed to by @p store (Currently
- * unused as of v0.0.2)
- * @param key The system value to query. See @ref SystemQuery
- * @param[out] store Pointer to memory where extra data will be copied, if needed, otherwise
- * ignored.
- * @returns The value of @p key as a system value upon the time of the call.
- */
-int _DWSystemQuery(SystemQuery key, void *store);
 
 /**
  * @brief Returns a string describing the meaning of @p status_code

--- a/dwuser/include/kernelapi.h
+++ b/dwuser/include/kernelapi.h
@@ -15,7 +15,6 @@
 #define SYSCALL_IDENTIFY         (0)
 #define SYSCALL_EXIT             (1)
 #define SYSCALL_YIELD            (2)
-#define SYSCALL_KLOG             (3)
 #define SYSCALL_REQUEST_PORTS    (4)
 #define SYSCALL_SEND             (5)
 #define SYSCALL_RECEIVE          (6)
@@ -203,19 +202,6 @@ void _cdecl noreturn _DWExit(void);
  * kernel is going to preemptively block the process and let a new one run.
  */
 void _cdecl _DWYield(void);
-
-/**
- * @brief _DWklog system call (#3) wrapper.
- * @details This will copy @p msg into the kernel log buffer, classifying it by @p level. Only
- * processes with the C_PROC_KLOG capability are allowed to use this system call. Processes not
- * assigned this capability can consider this system call a NOOP one.
- * @param level Severity of the log message, see @ref LogLevel for more details.
- * @param msg The message to write to the kernel logs. Must not be NULL.
- * @sa LogLevel
- */
-[[gnu::nonnull, deprecated("_DWklog is no longer available as a system call as the task of logging "
-                           "messages is left up to userland")]]
-void _cdecl _DWklog(LogLevel level, const char *msg);
 
 /**
  * @brief _DWRequestPorts system call (#4) wrapper.

--- a/dwuser/include/kerneltypes.h
+++ b/dwuser/include/kerneltypes.h
@@ -97,8 +97,12 @@ typedef enum _Status {
  * @brief Logging severity levels reexported from the kernel for the _DWklog system call (#3)
  * @details Used to classify log output by importance. Higher values indicate
  * more severe conditions.
+ * @deprecated The _DWklog system call is being deprecated as of v0.0.2 and this enum will be
+ * dropped alongside with it.
  */
-typedef enum {
+typedef enum [[deprecated(
+        "The _DWklog system call is being removed from DragonWare as of v0.0.2, and this type will "
+        "cease to be useful.")]] {
         LOG_DEBUG   = 0, /**< Debug-level messages (verbose, for development). */
         LOG_INFO    = 1, /**< Informational messages. */
         LOG_WARNING = 2, /**< Warning messages (non-fatal issues). */

--- a/dwuser/include/kerneltypes.h
+++ b/dwuser/include/kerneltypes.h
@@ -93,22 +93,6 @@ typedef enum _Status {
 #define KSUCCESS(s) ((Status)(s) == STATUS_OK)
 #define KFAILED(s)  ((Status)(s) != STATUS_OK)
 
-/**
- * @brief Logging severity levels reexported from the kernel for the _DWklog system call (#3)
- * @details Used to classify log output by importance. Higher values indicate
- * more severe conditions.
- * @deprecated The _DWklog system call is being deprecated as of v0.0.2 and this enum will be
- * dropped alongside with it.
- */
-typedef enum [[deprecated(
-        "The _DWklog system call is being removed from DragonWare as of v0.0.2, and this type will "
-        "cease to be useful.")]] {
-        LOG_DEBUG   = 0, /**< Debug-level messages (verbose, for development). */
-        LOG_INFO    = 1, /**< Informational messages. */
-        LOG_WARNING = 2, /**< Warning messages (non-fatal issues). */
-        LOG_ERROR   = 3, /**< Error messages (fatal or critical issues). */
-} LogLevel;
-
 DW_END_DECLS
 
 #endif /* _KERNEL_TYPES_H */

--- a/dwuser/syscall/syscall.c
+++ b/dwuser/syscall/syscall.c
@@ -22,10 +22,6 @@ void _cdecl noreturn _DWExit(void) {
 
 void _cdecl _DWYield(void) { __make_syscall_ia32_0param(SYSCALL_YIELD); }
 
-void _cdecl _DWklog(LogLevel level, const char *msg) {
-        __make_syscall_ia32_2param(SYSCALL_KLOG, (u32)level, (u32)msg);
-}
-
 Status _cdecl _DWRequestPorts(const u16 *port_list, Size port_list_size) {
         return (Status)__make_syscall_ia32_2param_reti32(SYSCALL_REQUEST_PORTS, (uint32_t)port_list,
                                                          (uint32_t)port_list_size);

--- a/dwuser/syscall/syscall.c
+++ b/dwuser/syscall/syscall.c
@@ -22,6 +22,11 @@ void _cdecl noreturn _DWExit(void) {
 
 void _cdecl _DWYield(void) { __make_syscall_ia32_0param(SYSCALL_YIELD); }
 
+int _cdecl _DWSystemQuery(SystemQuery key, void *store) {
+        return (int)__make_syscall_ia32_2param_reti32(SYSCALL_SYSTEM_QUERY, (uint32_t)key,
+                                                      (uint32_t)store);
+}
+
 Status _cdecl _DWRequestPorts(const u16 *port_list, Size port_list_size) {
         return (Status)__make_syscall_ia32_2param_reti32(SYSCALL_REQUEST_PORTS, (uint32_t)port_list,
                                                          (uint32_t)port_list_size);
@@ -55,9 +60,4 @@ void _DWDeleteObject(int handle) { __make_syscall_ia32_1param(SYSCALL_DELETE_OBJ
 Status _DWTranslateHandle(ProcessID process_id, int handle, int *save) {
         return __make_syscall_ia32_3param_reti32(SYSCALL_TRANSLATE_HANDLE, (uint32_t)process_id,
                                                  (uint32_t)handle, (uint32_t)save);
-}
-
-int _DWSystemQuery(SystemQuery key, void *store) {
-        return (int)__make_syscall_ia32_2param_reti32(SYSCALL_SYSTEM_QUERY, (uint32_t)key,
-                                                      (uint32_t)store);
 }

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -55,14 +55,6 @@ static void SystemIdentifySyscall(SystemIdentify *save) {
         (void)CopyToUser(save, &data, sizeof(SystemIdentify));
 }
 
-[[deprecated("_DWklog has been removed from the kernel in version v0.0.2")]]
-static void _DWklog(int level, const char *msg) {
-        char buf[LOG_MAXBUF];
-        ZeroMemory(buf);
-        if (CopyFromUser(buf, msg, strnlen(msg, LOG_MAXBUF)) != 0) return;
-        klog((LogLevel)level, "%s", buf);
-}
-
 static Status _DWRequestPorts(const u16 *port_list, Size list_size) {
         Process *current = GetCurrentExecutionThread()->owner;
         if (!(current->flags & PROC_C_IOPL))
@@ -104,9 +96,6 @@ void DragonWareSyscall(SystemCallFrame *regs) {
                 }
                 case SYSCALL_YIELD:
                         YieldCurrentThread();
-                        break;
-                case SYSCALL_KLOG:
-                        _DWklog((int)regs->ebx, (const char *)regs->esi);
                         break;
                 case SYSCALL_REQUEST_PORTS: {
                         ReturnFromSystemCall(regs, _DWRequestPorts, (u16 *)regs->ebx,

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -97,6 +97,10 @@ void DragonWareSyscall(SystemCallFrame *regs) {
                 case SYSCALL_YIELD:
                         YieldCurrentThread();
                         break;
+                case SYSCALL_SYSTEM_QUERY:
+                        ReturnFromSystemCall(regs, _DWSystemQuery, (SystemQuery)regs->ebx,
+                                             (void *)regs->esi);
+                        break;
                 case SYSCALL_REQUEST_PORTS: {
                         ReturnFromSystemCall(regs, _DWRequestPorts, (u16 *)regs->ebx,
                                              (Size)regs->esi);
@@ -128,10 +132,6 @@ void DragonWareSyscall(SystemCallFrame *regs) {
                 case SYSCALL_TRANSLATE_HANDLE:
                         ReturnFromSystemCall(regs, _DWTranslateHandle, (ProcessID)regs->ebx,
                                              (int)regs->esi, (int *)regs->edi);
-                        break;
-                case SYSCALL_SYSTEM_QUERY:
-                        ReturnFromSystemCall(regs, _DWSystemQuery, (SystemQuery)regs->ebx,
-                                             (void *)regs->esi);
                         break;
                 default:
                         regs->eax = (u32)STATUS_BAD_SYSCALL;

--- a/sys/syscall/syscall.c
+++ b/sys/syscall/syscall.c
@@ -55,6 +55,7 @@ static void SystemIdentifySyscall(SystemIdentify *save) {
         (void)CopyToUser(save, &data, sizeof(SystemIdentify));
 }
 
+[[deprecated("_DWklog has been removed from the kernel in version v0.0.2")]]
 static void _DWklog(int level, const char *msg) {
         char buf[LOG_MAXBUF];
         ZeroMemory(buf);

--- a/sys/syscall/syscall.h
+++ b/sys/syscall/syscall.h
@@ -14,7 +14,7 @@
 #define SYSCALL_IDENTIFY         (0)
 #define SYSCALL_EXIT             (1)
 #define SYSCALL_YIELD            (2)
-#define SYSCALL_KLOG             (3)
+#define SYSCALL_SYSTEM_QUERY     (3)
 #define SYSCALL_REQUEST_PORTS    (4) /* Replaced the old _DWRaiseIOPL syscall */
 #define SYSCALL_SEND             (5)
 #define SYSCALL_RECEIVE          (6)
@@ -23,7 +23,6 @@
 #define SYSCALL_INVOKE_OBJECT    (9)
 #define SYSCALL_DELETE_OBJECT    (10)
 #define SYSCALL_TRANSLATE_HANDLE (11)
-#define SYSCALL_SYSTEM_QUERY     (12)
 
 /* Only define those for the DragonWare kernel */
 #if __DRAGONWARE_SYS__


### PR DESCRIPTION
Three reasons for this:

1. The kernel should be able to log things (for the sake of debugging and making our lives easier), but a lot of code exists in it already that causes unnecessary complexity and possibly undiscovered bugs. A microkernel should be minimal and logging messages is definitely stretching it too far.

2. Userland now has a console provider to write to, if it needs to log things. In fact, only the PS/2 keyboard driver for some reason uses the _DWklog() system call, and it doesn't need to especially for the kinds of messages it logs.

3. The kernel has a tiny, fixed log buffer. It cannot afford to copy in there infinite amount of messages. This is possibly an Achilles' heel for the entire operating system.

About time we start cleaning up the kernel.

(Marking as draft for the time being, will merge once I drop the system call entirely)