### PR TITLE
Drop multicolor support and unused functionality from the builtin drivers

### DIFF
--- a/sys/drivers/serial86/com.c
+++ b/sys/drivers/serial86/com.c
@@ -17,7 +17,6 @@
 #include "iomgr/devmgr.h"
 #include "iomgr/node.h"
 #include "log.h"
-#include "video/pixels.h"
 
 #define COM1_PORT (0x3F8)
 
@@ -41,15 +40,6 @@ static inline void WriteToSerialPort(char c) {
 }
 
 #endif /* __K_DISABLE_SERIAL_OUTPUT */
-
-/* We can't control the colors of a serial port, so just have a dummy function that's like "yeah bro
- * totally I'm gonna show the text in red from the other side of the world. Rainbow gradient,
- * even..."*/
-static void _SetTextAttributes(void *private, PixelColor bg, PixelColor fg) {
-        UnusedParameter(private);
-        UnusedParameter(fg);
-        UnusedParameter(bg);
-}
 
 [[gnu::hot]]
 static void WriteSerialChar(void *private, char c) {
@@ -100,13 +90,10 @@ Status Serial86Init(void) {
                 return STATUS_OUT_OF_MEMORY;
         }
 
-        ConsoleDeviceOps console_ops = {.WriteSingleChar   = WriteSerialChar,
-                                        .SetTextAttributes = _SetTextAttributes,
-                                        .ResetConsole      = ResetSerialConsole,
-                                        .DeleteSingleChar  = NullPointer};
-        UARTDeviceOps    uart_ops    = {
-                      .WriteSingleChar = WriteSerialChar, .ReceiveByteFromSerial = NullPointer /* TODO */
-        };
+        ConsoleDeviceOps console_ops = {.WriteSingleChar  = WriteSerialChar,
+                                        .ResetConsole     = ResetSerialConsole,
+                                        .DeleteSingleChar = NullPointer};
+        UARTDeviceOps    uart_ops    = {.WriteSingleChar = WriteSerialChar};
 
         state->com1_enabled         = true;
         node->devtable.ddo->uart    = uart_ops;

--- a/sys/drivers/vbe86/driver.c
+++ b/sys/drivers/vbe86/driver.c
@@ -56,25 +56,23 @@ static inline void *SegmentedToLinearPointer(void *seg) {
 }
 
 [[gnu::hot]]
-static void WriteSinglePixel(void *privatedata, Size x, Size y, PixelColor color) {
+static void WriteSinglePixel(void *privatedata, Size x, Size y, int bw) {
+        u32               color = bw ? 0xEAEAEAEA : 0x00000000;
         FramebufferState *state = privatedata;
         switch (state->bpp) {
                 case 32: {
-                        u32 colorbytes = ColorToBytes32(color);
-
-                        PutPixel32(state->addr, state->width, x, y, colorbytes);
+                        PutPixel32(state->addr, state->width, x, y, color);
                         break;
                 }
                 case 24: {
-                        u32 colorbytes = ColorToBytes24(color);
-                        PutPixel24(state->addr, state->pitch, x, y, colorbytes);
+                        PutPixel24(state->addr, state->pitch, x, y, color);
                         break;
                 }
 
                 default:
                         LogMessage(LOG_WARNING,
                                    "Unknown framebuffer format. Assuming 32 bits per pixel.");
-                        PutPixel32(state->addr, state->width, x, y, ColorToBytes32(color));
+                        PutPixel32(state->addr, state->width, x, y, color);
                         break;
         }
 }
@@ -92,21 +90,9 @@ static void RenderGlyph(FramebufferState *state, Size x, Size y, Glyph *g) {
 
                         if (unlikely(px >= state->width || py >= state->height)) continue;
 
-                        PixelColor color = (bits & (0x80 >> col)) ? state->fg : state->bg;
-                        WriteSinglePixel(state, px, py, color);
-                }
-        }
-}
-static void DrawRectangle(void *privatedata, Size x, Size y, Size w, Size h, PixelColor color) {
-        FramebufferState *state = privatedata;
-        for (Size sx = x; sx < w; sx++) {
-                for (Size sy = y; sy < h; sy++) {
-                        if (state->bpp == 32)
-                                PutPixel32(state->addr, state->width, sx, sy,
-                                           ColorToBytes32(color));
-                        else if (state->bpp == 24)
-                                PutPixel24(state->addr, state->pitch, sx, sy,
-                                           ColorToBytes24(color));
+                        /* if this is nonzero, paint the font, otherwise paint the background*/
+                        int colored = (bits & (0x80 >> col));
+                        WriteSinglePixel(state, px, py, colored);
                 }
         }
 }
@@ -167,7 +153,7 @@ FramebufferInformation GetFramebufferInfo(void *privatedata) {
                  .height = state->height,
                  .bpp    = state->bpp,
                  .stride = state->pitch /* i believe stride and pitch are the same i dont remember
-                                      honestly */
+                                    honestly */
         };
         return info;
 }
@@ -178,30 +164,22 @@ static void DeleteSingleCharacter(void *privatedata) {
         WriteSingleCharacterAt(state, state->column, state->row, ' ');
 }
 
-static inline void SetColors(void *privatedata, PixelColor fg, PixelColor bg) {
-        FramebufferState *state = privatedata;
-        state->fg               = fg;
-        state->bg               = bg;
-}
-
 static void ClearFramebuffer(void *privatedata) {
         FramebufferState *state = privatedata;
         state->column           = 0;
         state->row              = 0;
         switch (state->bpp) {
                 case 32: {
-                        u32 color = ColorToBytes32(state->bg);
                         for (Size y = 0; y < state->height; y++) {
                                 for (Size x = 0; x < state->width; x++)
-                                        PutPixel32(state->addr, state->width, x, y, color);
+                                        PutPixel32(state->addr, state->width, x, y, 0);
                         }
                         break;
                 }
                 case 24: {
-                        u32 color = ColorToBytes24(state->bg);
                         for (Size y = 0; y < state->height; y++) {
                                 for (Size x = 0; x < state->width; x++)
-                                        PutPixel24(state->addr, state->pitch, x, y, color);
+                                        PutPixel24(state->addr, state->pitch, x, y, 0);
                         }
                         break;
                 }
@@ -216,10 +194,6 @@ static void ResetFramebufferConsole(void *privatedata) {
         state->row              = 0;
         state->column           = 0;
         ClearFramebuffer(privatedata);
-}
-
-static void SetConsoleColorAttributes(void *privatedata, PixelColor bg, PixelColor fg) {
-        SetColors(privatedata, fg, bg);
 }
 
 /* TODO: Mode information storing too */
@@ -318,17 +292,14 @@ Status VBE86DriverInit(void) {
 
         FramebufferDeviceOps fbddo = {
                 .WriteSinglePixel          = WriteSinglePixel,
-                .BlitRectangle             = DrawRectangle,
-                .SetCurrentOutputColors    = SetColors,
                 .ClearScreen               = ClearFramebuffer,
                 .Flush                     = FlushFramebuffer,
                 .GetFramebufferInformation = GetFramebufferInfo,
         };
 
-        ConsoleDeviceOps conddo       = {.WriteSingleChar   = WriteSingleCharacter,
-                                         .DeleteSingleChar  = DeleteSingleCharacter,
-                                         .ResetConsole      = ResetFramebufferConsole,
-                                         .SetTextAttributes = SetConsoleColorAttributes};
+        ConsoleDeviceOps conddo       = {.WriteSingleChar  = WriteSingleCharacter,
+                                         .DeleteSingleChar = DeleteSingleCharacter,
+                                         .ResetConsole     = ResetFramebufferConsole};
         fb->devtable.ddo->framebuffer = fbddo;
         fb->devtable.ddo->console     = conddo;
 
@@ -361,8 +332,6 @@ Status VBE86DriverInit(void) {
         /* Easier than just casting every time */
         FramebufferState *state = fb->private_state;
         state->addr             = (void *)FRAMEBUFFER_ADDR;
-        state->bg               = BlackPixel;
-        state->fg               = WhitePixel;
         state->bpp              = bootinfo->bpp;
         state->width            = bootinfo->fbwidth;
         state->height           = bootinfo->fbheight;

--- a/sys/drivers/vbe86/fbstate.h
+++ b/sys/drivers/vbe86/fbstate.h
@@ -11,13 +11,10 @@
 
 #include <ktypes.h>
 
-#include "video/pixels.h"
-
 typedef struct _FramebufferState {
-        Size       column, row, pixels_per_char;
-        Size       width, height, pitch;
-        Byte       bpp;
-        Bool       text_mode;
-        PixelColor fg, bg;
-        void      *addr;
+        Size  column, row, pixels_per_char;
+        Size  width, height, pitch;
+        Byte  bpp;
+        Bool  text_mode;
+        void *addr;
 } FramebufferState;

--- a/sys/drivers/vgatext/textmode.c
+++ b/sys/drivers/vgatext/textmode.c
@@ -77,31 +77,6 @@ static inline u16 VGAGetCharacterWithColor(char uc, Byte color) {
         return (u16)uc | (u16)((u16)color << 8);
 }
 
-static VGAColor VGAMatchColorToKernel(PixelColor p) {
-        switch (p) {
-                case WhitePixel:
-                        return VGATEXT_COLOR_LIGHT_GREY;
-                case RedPixel:
-                        return VGATEXT_COLOR_RED;
-                case OrangePixel:
-                        return VGATEXT_COLOR_LIGHT_BROWN; /* There's no orange */
-                case GreenPixel:
-                        return VGATEXT_COLOR_GREEN;
-                case PrussianPixel:
-                case BluePixel:
-                        return VGATEXT_COLOR_BLUE;
-                case LightGrayPixel:
-                        return VGATEXT_COLOR_LIGHT_GREY;
-                case CyanPixel:
-                        return VGATEXT_COLOR_CYAN;
-                case MagentaPixel:
-                        return VGATEXT_COLOR_LIGHT_MAGENTA;
-                case BlackPixel:
-                default:
-                        return VGATEXT_COLOR_BLACK;
-        }
-}
-
 void VGASetCursorPosition(unsigned int x, unsigned int y) {
         u16 pos = (u16)(((u16)x) * VGA_WIDTH + y);
         outb(0x3D4, (Byte)0x0E);
@@ -176,12 +151,6 @@ static void VGAClearAllText(void *private_state) {
         state->column = 0;
 }
 
-static void VGASetColorMode(void *private_state, PixelColor bg, PixelColor fg) {
-        VGATextModeState *state = private_state;
-        state->colorattr =
-                VGAGetColorAttribute(VGAMatchColorToKernel(fg), VGAMatchColorToKernel(bg));
-}
-
 static void VGADeleteSingleCharacter(void *privatedata) {
         VGATextModeState *state = privatedata;
         VGAPrintCharacterAt(privatedata, state->column, state->row, ' ');
@@ -238,10 +207,9 @@ Status VGATextInit(void) {
         state->row        = 0;
         state->init       = true;
 
-        ConsoleDeviceOps console_operations = {.WriteSingleChar   = VGAPrintCharacter,
-                                               .ResetConsole      = VGAClearAllText,
-                                               .DeleteSingleChar  = VGADeleteSingleCharacter,
-                                               .SetTextAttributes = VGASetColorMode};
+        ConsoleDeviceOps console_operations = {.WriteSingleChar  = VGAPrintCharacter,
+                                               .ResetConsole     = VGAClearAllText,
+                                               .DeleteSingleChar = VGADeleteSingleCharacter};
         vganode->devtable.ddo->console      = console_operations;
         vganode->private_state              = state;
         vganode->attr.kernel_mapped_addr    = FRAMEBUFFER_ADDR;

--- a/sys/iomgr/class.h
+++ b/sys/iomgr/class.h
@@ -11,8 +11,6 @@
 
 #include <ktypes.h>
 
-#include "video/pixels.h"
-
 /* Remember: A device may be able to do more than one thing. For example, the GPU is able to blit on
  * the screen as well as run custom code. So I've went with bitfields using  */
 
@@ -42,23 +40,18 @@ typedef struct _FramebufferInformation {
 } FramebufferInformation;
 
 typedef struct _FramebufferDeviceOps {
-        void (*WriteSinglePixel)(void *privatedata, Size x, Size y, PixelColor color);
-        void (*BlitRectangle)(void *privatedata, Size startx, Size starty, Size width, Size height,
-                              PixelColor color);
-        void (*Flush)(void *privatedata);
-        void (*SetCurrentOutputColors)(void *privatedata, PixelColor fg, PixelColor bg);
-        void (*ClearScreen)(void *privatedata);
+        void                   (*WriteSinglePixel)(void *privatedata, Size x, Size y, int bw);
+        void                   (*Flush)(void *privatedata);
+        void                   (*ClearScreen)(void *privatedata);
         FramebufferInformation (*GetFramebufferInformation)(void *privatedata);
 } FramebufferDeviceOps;
 
 typedef struct _ConsoleDeviceOps {
         void (*WriteSingleChar)(void *privatedata, char c);
-        void (*SetTextAttributes)(void *privatedata, PixelColor background, PixelColor foreground);
         void (*ResetConsole)(void *privatedata);
         void (*DeleteSingleChar)(void *privatedata);
 } ConsoleDeviceOps;
 
 typedef struct _UARTDeviceOps {
         void (*WriteSingleChar)(void *privatedata, char c);
-        Byte (*ReceiveByteFromSerial)(void *privatedata);
 } UARTDeviceOps;

--- a/sys/lib/log.c
+++ b/sys/lib/log.c
@@ -17,9 +17,7 @@
 #include "iomgr/class.h"
 #include "iomgr/node.h"
 #include "video/output.h"
-#include "video/pixels.h"
 
-#define BUFSIZE 32
 #ifndef LOG_BUFSIZE
 #define LOG_BUFSIZE (64)
 #endif
@@ -29,17 +27,14 @@ static LogMessage logbuffer[LOG_BUFSIZE] = {0};
 static Size       logbuf_idx             = 0;
 static Bool       logs_flushed           = false;
 
-static void PrintToOutputs(const char *msg, PixelColor bg, PixelColor fg) {
+static void PrintToOutputs(const char *msg) {
         Size len = strlen(msg);
 #ifdef DRAGONWARE_DEBUG_MODE
         ForEachConsoleDevice({
                 DeviceManagerNode *out = curr->node; /* curr given by the macro */
-                out->devtable.ddo->console.SetTextAttributes(out->private_state, bg, fg);
                 for (Size i = 0; i < len; i++) {
                         out->devtable.ddo->console.WriteSingleChar(out->private_state, msg[i]);
                 }
-                out->devtable.ddo->console.SetTextAttributes(out->private_state, BlackPixel,
-                                                             WhitePixel);
         });
 #else
         OutputNode *out = GetPrimaryOutputDevice();
@@ -52,35 +47,28 @@ static void PrintToOutputs(const char *msg, PixelColor bg, PixelColor fg) {
 }
 
 static void PrintPrefixFor(LogLevel level) {
-        char      *prefix = "????? ";
-        PixelColor fg     = WhitePixel;
+        char *prefix = "????? ";
         switch (level) {
                 case LOG_DEBUG: {
                         prefix = "* DEBUG   ";
-                        fg     = CyanPixel;
                         break;
                 }
                 case LOG_INFO: {
                         prefix = "* INFO    ";
-                        fg     = GreenPixel;
                         break;
                 }
                 case LOG_WARNING: {
                         prefix = "* WARNING ";
-                        fg     = OrangePixel;
                         break;
                 }
                 case LOG_ERROR: {
                         prefix = "* ERROR   ";
-                        fg     = RedPixel;
                         break;
                 }
-                default: {
-                        fg = LightGrayPixel;
+                default:
                         break;
-                }
         }
-        PrintToOutputs(prefix, BlackPixel, fg);
+        PrintToOutputs(prefix);
 }
 
 void LogInit(void) {
@@ -100,8 +88,8 @@ void klog(LogLevel level, const char *fmt, ...) {
          * checking if the logs were flushed before. If so, we can now start printing. */
         if (logs_flushed) {
                 PrintPrefixFor(level);
-                PrintToOutputs(buf, BlackPixel, WhitePixel);
-                PrintToOutputs("\n", BlackPixel, WhitePixel);
+                PrintToOutputs(buf);
+                PrintToOutputs("\n");
         }
 
         if ((logbuf_idx + 1) >= arraysize(logbuffer)) return;
@@ -117,8 +105,8 @@ void FlushAllLogs(void) {
 
         for (Size i = 0; i < logbuf_idx; i++) {
                 PrintPrefixFor(logbuffer[i].code);
-                PrintToOutputs(logbuffer[i].buffer, BlackPixel, WhitePixel);
-                PrintToOutputs("\n", BlackPixel, WhitePixel);
+                PrintToOutputs(logbuffer[i].buffer);
+                PrintToOutputs("\n");
         }
         logs_flushed = true;
 }

--- a/sys/lib/log.c
+++ b/sys/lib/log.c
@@ -39,8 +39,6 @@ static void PrintToOutputs(const char *msg) {
 #else
         OutputNode *out = GetPrimaryOutputDevice();
         if (!out) return; /* No output to print on, wait for devices to come online*/
-        DeviceManagerNode *dev = out->node;
-        dev->devtable.ddo->console.SetTextAttributes(dev->private_state, bg, fg);
         for (Size i = 0; i < len; i++)
                 out->node->devtable.ddo->console.WriteSingleChar(out->node->private_state, msg[i]);
 #endif /* DRAGONWARE_DEBUG_MODE */

--- a/sys/lib/panic.c
+++ b/sys/lib/panic.c
@@ -18,7 +18,6 @@
 #include "ddk/ia32/interrupts.h"
 #include "iomgr/node.h"
 #include "video/output.h"
-#include "video/pixels.h"
 
 #define NUMBUF_REG (32)
 
@@ -162,12 +161,8 @@ void FatalError(const char *fmt, ...) {
         if (!panicking) {
                 panicking = true;
                 ForEachConsoleDevice({
-                        DeviceManagerNode *out = curr->node;
-                        void               (*SetTextAttributes)(void *, PixelColor, PixelColor) =
-                                out->devtable.ddo->console.SetTextAttributes;
+                        DeviceManagerNode *out       = curr->node;
                         void (*ResetConsole)(void *) = out->devtable.ddo->console.ResetConsole;
-                        if (SetTextAttributes)
-                                SetTextAttributes(out->private_state, RedPixel, WhitePixel);
                         if (ResetConsole) ResetConsole(out->private_state);
                 });
                 PrintStringToAllOutputs("\n");
@@ -299,12 +294,8 @@ void FatalErrorWithStackFrame(InterruptStackFrame *stack_frame, const char *msg,
         if (!panicking) {
                 panicking = true;
                 ForEachConsoleDevice({
-                        DeviceManagerNode *out = curr->node;
-                        void               (*SetTextAttributes)(void *, PixelColor, PixelColor) =
-                                out->devtable.ddo->console.SetTextAttributes;
+                        DeviceManagerNode *out       = curr->node;
                         void (*ResetConsole)(void *) = out->devtable.ddo->console.ResetConsole;
-                        if (SetTextAttributes)
-                                SetTextAttributes(out->private_state, RedPixel, WhitePixel);
                         if (ResetConsole) ResetConsole(out->private_state);
                 });
                 PrintStringToAllOutputs("\n");

--- a/sys/video/pixels.h
+++ b/sys/video/pixels.h
@@ -19,22 +19,6 @@
 #define PIXEL_INDEX(_x, _y, _fbwidth) (_y * _fbwidth + _x)
 #define AREA_2D(_x, _y)               (_x * _y)
 
-/** @brief A single pixel's color to be used with pixel manipulation/plotting functions. */
-typedef enum _PixelColor {
-        BlackPixel,
-        WhitePixel,
-        RedPixel,
-        GreenPixel,
-        BluePixel,
-        LightBluePixel,
-        YellowPixel,
-        OrangePixel,
-        MagentaPixel,
-        CyanPixel,
-        LightGrayPixel,
-        PrussianPixel
-} PixelColor;
-
 /**
  * @brief Writes a single color value to the given 8-bit framebuffer, at the given location.
  * @param addr The framebuffer address that will be written to. Usually @ref FRAMEBUFFER_ADDR
@@ -66,45 +50,6 @@ static inline void PutPixel16(u16 *addr, unsigned long fbwidth, unsigned long x,
 }
 
 /**
- * @brief Returns a pixel's color based on a given @ref PixelColor as a 32 bit value (the higher
- * four bits are ignored).
- * @param p The pixel color that must be converted.
- * @returns The 32 bit integer version of the given @ref PixelColor in RGB format, or 0x00000000 if
- * the color couldn't be matched.
- * @warning Blitting with non-powers of two is very expensive to the CPU.
- */
-static inline u32 ColorToBytes24(PixelColor p) {
-        switch (p) {
-                case BlackPixel:
-                        return 0x00000000;
-                case WhitePixel:
-                        return 0x00FFFFFF - 1;
-                case RedPixel:
-                        return 0x00FF0000;
-                case GreenPixel:
-                        return 0x0000FF00;
-                case BluePixel:
-                        return 0x00000088;
-                case LightBluePixel:
-                        return 0x000077FF;
-                case YellowPixel:
-                        return 0x00FFFF00;
-                case OrangePixel:
-                        return 0x00FF9900;
-                case MagentaPixel:
-                        return 0x00FF00FF;
-                case CyanPixel:
-                        return 0x0000DDFF;
-                case LightGrayPixel:
-                        return 0x00333333;
-                case PrussianPixel:
-                        return 0x00010410;
-                default:
-                        return ColorToBytes24(BlackPixel);
-        }
-}
-
-/**
  * @brief Writes a single color value to the given 24-bit framebuffer, at the given location.
  * @param addr The framebuffer address that will be written to. Usually @ref FRAMEBUFFER_ADDR
  * @param pitch The pitch (Bytes per scanline) of the framebuffer, see @ref VBEModeInfo
@@ -116,9 +61,8 @@ static inline u32 ColorToBytes24(PixelColor p) {
  * separately as an 8 bit value.
  */
 static inline void PutPixel24(u8 *addr, unsigned long pitch, unsigned long x, unsigned long y,
-                              PixelColor clr) {
+                              u32 color) {
         u8 *row        = addr + y * pitch;
-        u32 color      = ColorToBytes24(clr);
         row[x * 3 + 0] = color & 0xFF;
         row[x * 3 + 1] = (color >> 8) & 0xFF;
         row[x * 3 + 2] = (color >> 16) & 0xFF;
@@ -138,41 +82,4 @@ static inline void PutPixel32(u32 *addr, unsigned long fbwidth, unsigned long x,
         Size idx  = PIXEL_INDEX(x, y, fbwidth);
         addr[idx] = color;  // NOLINT(clang-analyzer-core.FixedAddressDereference)
         /* (that NOLINT line above is because clang-tidy thinks we're doing something stupid )*/
-}
-
-/**
- * @brief Returns a pixel's color based on a given @ref PixelColor as a 32 bit value.
- * @param p The pixel color that must be converted.
- * @returns The 32 bit integer version of the given @ref PixelColor in RGBA format, or 0x00000000 if
- * the color couldn't be matched.
- */
-static inline u32 ColorToBytes32(PixelColor p) {
-        switch (p) {
-                case BlackPixel:
-                        return 0x00000000;
-                case WhitePixel:
-                        return 0xFFFFFFFF;
-                case RedPixel:
-                        return 0xFFFF0000;
-                case GreenPixel:
-                        return 0xFF00FF00;
-                case BluePixel:
-                        return 0xFF0000FF;
-                case LightBluePixel:
-                        return 0xFF0077FF;
-                case YellowPixel:
-                        return 0xFFFF00FF;
-                case OrangePixel:
-                        return 0xFFFF9900;
-                case MagentaPixel:
-                        return 0xFF00FFFF;
-                case CyanPixel:
-                        return 0xFF00DDFF;
-                case LightGrayPixel:
-                        return 0x11111111;
-                case PrussianPixel:
-                        return 0xFF010410;
-                default:
-                        return ColorToBytes32(BlackPixel);
-        }
 }


### PR DESCRIPTION
A microkernel shouldn't have drivers inside kernel space for drawing rectangles, complicated pixel format color conversion and all that. While this will make the kernel messages during boot colorless, it will make DragonWare align more with the microkernel model and prevent bugs in the future, as we are slowly approaching SMP and we need a clean codebase to work with (Every driver had its own internal state and we'd have to use locks to modify the state in one CPU without racing with another).

Not breaking or even affecting anything outside the visuals, but I'd still like to run a few tests in some odd 24-bit bpp cards before I merge this, hence marking it as draft, in case I need to make any bug fixes.

Signed-off-by: Aggelos Tselios <aggelostselios777@gmail.com>